### PR TITLE
Fix isEqual comparison for empty id lists

### DIFF
--- a/src/ValueObject/IdList.php
+++ b/src/ValueObject/IdList.php
@@ -164,7 +164,17 @@ abstract class IdList implements \Iterator, \Countable
 
     public function isEqualTo(self $idList): bool
     {
-        return $this->diff($idList)->count() === 0;
+        if ($this->count() !== $idList->count()) {
+            return false;
+        }
+
+        foreach ($this->ids as $id) {
+            if ($idList->notContainsId($id)) {
+                return false;
+            }
+        }
+
+        return true;
     }
 
     public function isNotEqualTo(self $idList): bool

--- a/src/ValueObject/MutableIdList.php
+++ b/src/ValueObject/MutableIdList.php
@@ -170,6 +170,10 @@ abstract class MutableIdList implements \Iterator, \Countable
 
     public function isEqualTo(self $idList): bool
     {
+        if ($this->count() !== $idList->count()) {
+            return false;
+        }
+
         foreach ($this->ids as $id) {
             if ($idList->notContainsId($id)) {
                 return false;

--- a/tests/ValueObject/IdListTest.php
+++ b/tests/ValueObject/IdListTest.php
@@ -569,6 +569,52 @@ final class IdListTest extends TestCase
 
     /**
      * @test
+     * @covers ::isEqualTo
+     * @covers ::isNotEqualTo
+     */
+    public function empty_id_list_is_not_equal_to(): void
+    {
+        // -- Arrange
+        $idTom = UserId::generateRandom();
+        $idMarkus = UserId::generateRandom();
+
+        $emptyIdList = UserIdList::fromIds([]);
+        $userIdList = UserIdList::fromIds([
+            $idTom,
+            $idMarkus,
+        ]);
+
+        // -- Act & Assert
+        $this->assertFalse($emptyIdList->isEqualTo($userIdList));
+
+        $this->assertTrue($emptyIdList->isNotEqualTo($userIdList));
+    }
+
+    /**
+     * @test
+     * @covers ::isEqualTo
+     * @covers ::isNotEqualTo
+     */
+    public function id_list_is_not_equal_to_empty_id_List(): void
+    {
+        // -- Arrange
+        $idTom = UserId::generateRandom();
+        $idMarkus = UserId::generateRandom();
+
+        $emptyIdList = UserIdList::fromIds([]);
+        $userIdList = UserIdList::fromIds([
+            $idTom,
+            $idMarkus,
+        ]);
+
+        // -- Act & Assert
+        $this->assertFalse($userIdList->isEqualTo($emptyIdList));
+
+        $this->assertTrue($userIdList->isNotEqualTo($emptyIdList));
+    }
+
+    /**
+     * @test
      * @covers ::mustBeEqualTo
      */
     public function must_not_be_equal_to(): void

--- a/tests/ValueObject/IdListTest.php
+++ b/tests/ValueObject/IdListTest.php
@@ -595,7 +595,7 @@ final class IdListTest extends TestCase
      * @covers ::isEqualTo
      * @covers ::isNotEqualTo
      */
-    public function id_list_is_not_equal_to_empty_id_List(): void
+    public function id_list_is_not_equal_to_empty_id_list(): void
     {
         // -- Arrange
         $idTom = UserId::generateRandom();

--- a/tests/ValueObject/MutableIdListTest.php
+++ b/tests/ValueObject/MutableIdListTest.php
@@ -591,7 +591,7 @@ final class MutableIdListTest extends TestCase
      * @covers ::isEqualTo
      * @covers ::isNotEqualTo
      */
-    public function id_list_is_not_equal_to_empty_id_List(): void
+    public function id_list_is_not_equal_to_empty_id_list(): void
     {
         // -- Arrange
         $idTom = UserId::generateRandom();

--- a/tests/ValueObject/MutableIdListTest.php
+++ b/tests/ValueObject/MutableIdListTest.php
@@ -530,7 +530,6 @@ final class MutableIdListTest extends TestCase
      */
     public function id_list_is_equal_to(): void
     {
-
         // -- Arrange
         $idAnton = UserId::generateRandom();
         $idMarkus = UserId::generateRandom();

--- a/tests/ValueObject/MutableIdListTest.php
+++ b/tests/ValueObject/MutableIdListTest.php
@@ -565,6 +565,52 @@ final class MutableIdListTest extends TestCase
 
     /**
      * @test
+     * @covers ::isEqualTo
+     * @covers ::isNotEqualTo
+     */
+    public function empty_id_list_is_not_equal_to(): void
+    {
+        // -- Arrange
+        $idTom = UserId::generateRandom();
+        $idMarkus = UserId::generateRandom();
+
+        $emptyIdList = MutableUserIdList::fromIds([]);
+        $userIdList = MutableUserIdList::fromIds([
+            $idTom,
+            $idMarkus,
+        ]);
+
+        // -- Act & Assert
+        $this->assertFalse($emptyIdList->isEqualTo($userIdList));
+
+        $this->assertTrue($emptyIdList->isNotEqualTo($userIdList));
+    }
+
+    /**
+     * @test
+     * @covers ::isEqualTo
+     * @covers ::isNotEqualTo
+     */
+    public function id_list_is_not_equal_to_empty_id_List(): void
+    {
+        // -- Arrange
+        $idTom = UserId::generateRandom();
+        $idMarkus = UserId::generateRandom();
+
+        $emptyIdList = MutableUserIdList::fromIds([]);
+        $userIdList = MutableUserIdList::fromIds([
+            $idTom,
+            $idMarkus,
+        ]);
+
+        // -- Act & Assert
+        $this->assertFalse($userIdList->isEqualTo($emptyIdList));
+
+        $this->assertTrue($userIdList->isNotEqualTo($emptyIdList));
+    }
+
+    /**
+     * @test
      * @covers ::mustBeEqualTo
      */
     public function must_not_be_equal_to(): void

--- a/tests/ValueObject/MutableIdListTest.php
+++ b/tests/ValueObject/MutableIdListTest.php
@@ -530,6 +530,7 @@ final class MutableIdListTest extends TestCase
      */
     public function id_list_is_equal_to(): void
     {
+
         // -- Arrange
         $idAnton = UserId::generateRandom();
         $idMarkus = UserId::generateRandom();

--- a/tests/ValueObject/MutableIdListTest.php
+++ b/tests/ValueObject/MutableIdListTest.php
@@ -574,16 +574,16 @@ final class MutableIdListTest extends TestCase
         $idTom = UserId::generateRandom();
         $idMarkus = UserId::generateRandom();
 
-        $emptyIdList = MutableUserIdList::fromIds([]);
-        $userIdList = MutableUserIdList::fromIds([
+        $mutableEmptyUserIdList = MutableUserIdList::fromIds([]);
+        $mutableUserIdList = MutableUserIdList::fromIds([
             $idTom,
             $idMarkus,
         ]);
 
         // -- Act & Assert
-        $this->assertFalse($emptyIdList->isEqualTo($userIdList));
+        $this->assertFalse($mutableEmptyUserIdList->isEqualTo($mutableUserIdList));
 
-        $this->assertTrue($emptyIdList->isNotEqualTo($userIdList));
+        $this->assertTrue($mutableEmptyUserIdList->isNotEqualTo($mutableUserIdList));
     }
 
     /**
@@ -597,16 +597,16 @@ final class MutableIdListTest extends TestCase
         $idTom = UserId::generateRandom();
         $idMarkus = UserId::generateRandom();
 
-        $emptyIdList = MutableUserIdList::fromIds([]);
-        $userIdList = MutableUserIdList::fromIds([
+        $mutableEmptyUserIdList = MutableUserIdList::fromIds([]);
+        $mutableUserIdList = MutableUserIdList::fromIds([
             $idTom,
             $idMarkus,
         ]);
 
         // -- Act & Assert
-        $this->assertFalse($userIdList->isEqualTo($emptyIdList));
+        $this->assertFalse($mutableUserIdList->isEqualTo($mutableEmptyUserIdList));
 
-        $this->assertTrue($userIdList->isNotEqualTo($emptyIdList));
+        $this->assertTrue($mutableUserIdList->isNotEqualTo($mutableEmptyUserIdList));
     }
 
     /**


### PR DESCRIPTION
Previously, there was a small bug when using the isEqual function. For example, when comparing an empty ID list with a filled ID list, true was returned for isEqual, although both lists cannot be identical based on the length.

Also, I removed the usage of diff() within the isEqual function. Creating a new list isn`t needed. 