### PR TITLE
Fix diff function of lists

### DIFF
--- a/src/ValueObject/IdList.php
+++ b/src/ValueObject/IdList.php
@@ -111,8 +111,15 @@ abstract class IdList implements \Iterator, \Countable
                 $idsNotInList[] = $id;
             }
         }
+        foreach ($idList as $id) {
+            if ($this->notContainsId($id)) {
+                $idsNotInList[] = $id;
+            }
+        }
 
-        return new static($idsNotInList);
+        $uniqueIds = array_unique($idsNotInList, SORT_STRING);
+
+        return new static($uniqueIds);
     }
 
     /**

--- a/src/ValueObject/MutableIdList.php
+++ b/src/ValueObject/MutableIdList.php
@@ -106,8 +106,15 @@ abstract class MutableIdList implements \Iterator, \Countable
                 $idsNotInList[] = $id;
             }
         }
+        foreach ($idList as $id) {
+            if ($this->notContainsId($id)) {
+                $idsNotInList[] = $id;
+            }
+        }
 
-        $this->ids = $idsNotInList;
+        $uniqueIds = array_unique($idsNotInList, SORT_STRING);
+
+        $this->ids = $uniqueIds;
     }
 
     /**

--- a/tests/ValueObject/IdListTest.php
+++ b/tests/ValueObject/IdListTest.php
@@ -273,13 +273,48 @@ final class IdListTest extends TestCase
         ]);
 
         // -- Act
-        $diffList = $originalList->diff($partialList);
+        $diffListFromOriginalList = $originalList->diff($partialList);
+        $diffListFromPartialList = $partialList->diff($originalList);
 
         // -- Assert
-        self::assertCount(2, $diffList);
+        self::assertCount(2, $diffListFromOriginalList);
+        self::assertCount(2, $diffListFromPartialList);
 
-        self::assertTrue($diffList->containsId($idMarkus));
-        self::assertTrue($diffList->containsId($idTom));
+        self::assertTrue($diffListFromOriginalList->containsId($idMarkus));
+        self::assertTrue($diffListFromOriginalList->containsId($idTom));
+
+        self::assertTrue($diffListFromPartialList->containsId($idMarkus));
+        self::assertTrue($diffListFromPartialList->containsId($idTom));
+    }
+
+    /**
+     * @test
+     * @covers ::diff
+     */
+    public function id_list_diff_works_with_empty_list(): void
+    {
+        // -- Arrange
+        $idAnton = UserId::generateRandom();
+        $idMarkus = UserId::generateRandom();
+        $idPaul = UserId::generateRandom();
+        $idTom = UserId::generateRandom();
+
+        $originalList = UserIdList::fromIds([
+            $idAnton,
+            $idMarkus,
+            $idPaul,
+            $idTom,
+        ]);
+
+        $emptyList = UserIdList::emptyList();
+
+        // -- Act
+        $diffListFromOriginal = $originalList->diff($emptyList);
+        $diffListFromEmpty = $emptyList->diff($originalList);
+
+        // -- Assert
+        self::assertCount(4, $diffListFromOriginal);
+        self::assertCount(4, $diffListFromEmpty);
     }
 
     // -- Intersect

--- a/tests/ValueObject/MutableIdListTest.php
+++ b/tests/ValueObject/MutableIdListTest.php
@@ -256,26 +256,78 @@ final class MutableIdListTest extends TestCase
         $idPaul = UserId::generateRandom();
         $idTom = UserId::generateRandom();
 
-        $fullList = MutableUserIdList::fromIds([
+        $fullList1 = MutableUserIdList::fromIds([
             $idAnton,
             $idMarkus,
             $idPaul,
             $idTom,
         ]);
+        $partialList1 = MutableUserIdList::fromIds([
+            $idAnton,
+            $idPaul,
+        ]);
 
-        $partialList = MutableUserIdList::fromIds([
+        $fullList2 = MutableUserIdList::fromIds([
+            $idAnton,
+            $idMarkus,
+            $idPaul,
+            $idTom,
+        ]);
+        $partialList2 = MutableUserIdList::fromIds([
             $idAnton,
             $idPaul,
         ]);
 
         // -- Act
-        $fullList->diff($partialList);
+        $fullList1->diff($partialList1);
+        $partialList2->diff($fullList2);
 
         // -- Assert
-        self::assertCount(2, $fullList);
+        self::assertCount(2, $fullList1);
+        self::assertCount(2, $partialList2);
 
-        self::assertTrue($fullList->containsId($idMarkus));
-        self::assertTrue($fullList->containsId($idTom));
+        self::assertTrue($fullList1->containsId($idMarkus));
+        self::assertTrue($fullList1->containsId($idTom));
+
+        self::assertTrue($partialList2->containsId($idMarkus));
+        self::assertTrue($partialList2->containsId($idTom));
+    }
+
+    /**
+     * @test
+     * @covers ::diff
+     */
+    public function id_list_diff_works_with_empty(): void
+    {
+        // -- Arrange
+        $idAnton = UserId::generateRandom();
+        $idMarkus = UserId::generateRandom();
+        $idPaul = UserId::generateRandom();
+        $idTom = UserId::generateRandom();
+
+        $fullList1 = MutableUserIdList::fromIds([
+            $idAnton,
+            $idMarkus,
+            $idPaul,
+            $idTom,
+        ]);
+        $emptyList1 = MutableUserIdList::emptyList();
+
+        $fullList2 = MutableUserIdList::fromIds([
+            $idAnton,
+            $idMarkus,
+            $idPaul,
+            $idTom,
+        ]);
+        $emptyList2 = MutableUserIdList::emptyList();
+
+        // -- Act
+        $fullList1->diff($emptyList1);
+        $emptyList2->diff($fullList2);
+
+        // -- Assert
+        self::assertCount(4, $fullList1);
+        self::assertCount(4, $emptyList2);
     }
 
     // -- Intersect


### PR DESCRIPTION
## Changes

- `diff` only cared about the elements of the original list on which `diff()` was called, but not the second list. This is now fixed in both lists.