### PR TITLE
Add ext uuid and symfony/polyfill-uuid to suggest instead of requirements

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Install package through composer:
 composer require digital-craftsman/ids
 ```
 
-Additionally, you ether need the `uuid` PHP extension installed or the polyfill `symfony/polyfill-uuid` as part of your composer requirements. Using the `uuid` extension is around twice as fast when handling thousands of ids in one request.
+Additionally, you ether need the [`uuid` PHP extension](https://pecl.php.net/package/uuid) installed or the polyfill `symfony/polyfill-uuid` as part of your composer requirements. Using the `uuid` extension is around twice as fast when handling thousands of ids in one request.
 
 ## Working with ids
 

--- a/README.md
+++ b/README.md
@@ -9,6 +9,16 @@ As it's a central part of an application, it's tested thoroughly.
 [![Total Downloads](http://poser.pugx.org/digital-craftsman/ids/downloads)](https://packagist.org/packages/digital-craftsman/ids)
 [![License](http://poser.pugx.org/digital-craftsman/ids/license)](https://packagist.org/packages/digital-craftsman/ids)
 
+## Installation and configuration
+
+Install package through composer:
+
+```shell
+composer require digital-craftsman/ids
+```
+
+Additionally, you ether need the `uuid` PHP extension installed or the polyfill `symfony/polyfill-uuid` in your composer requirements.
+
 ## Working with ids
 
 ### Creating a new id

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Install package through composer:
 composer require digital-craftsman/ids
 ```
 
-Additionally, you ether need the `uuid` PHP extension installed or the polyfill `symfony/polyfill-uuid` in your composer requirements.
+Additionally, you ether need the `uuid` PHP extension installed or the polyfill `symfony/polyfill-uuid` in your composer requirements. Using the `uuid` extension is around twice as fast when handling thousands of ids in one request.
 
 ## Working with ids
 

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Install package through composer:
 composer require digital-craftsman/ids
 ```
 
-Additionally, you ether need the `uuid` PHP extension installed or the polyfill `symfony/polyfill-uuid` in your composer requirements. Using the `uuid` extension is around twice as fast when handling thousands of ids in one request.
+Additionally, you ether need the `uuid` PHP extension installed or the polyfill `symfony/polyfill-uuid` as part of your composer requirements. Using the `uuid` extension is around twice as fast when handling thousands of ids in one request.
 
 ## Working with ids
 

--- a/composer.json
+++ b/composer.json
@@ -6,16 +6,18 @@
     "php": "8.0.*|8.1.*",
     "symfony/framework-bundle": "^5.4|^6.0",
     "symfony/serializer": "^5.4|^6.0",
-    "doctrine/dbal": "^2.13.8|^3.3.6",
-    "symfony/polyfill-uuid": "^1.26"
+    "doctrine/dbal": "^2.13.8|^3.3.6"
   },
   "require-dev": {
     "vimeo/psalm": "^4.12",
     "friendsofphp/php-cs-fixer": "^3.3",
-    "phpunit/phpunit": "^9.5"
+    "phpunit/phpunit": "^9.5",
+    "symfony/polyfill-uuid": "^1.26",
+    "ext-uuid": "^1.2"
   },
   "suggest": {
-    "ext-uuid": "*"
+    "ext-uuid": "Necessary for uuid creation. You need ether the uuid extension or symfony/polyfill-uuid.",
+    "symfony/polyfill-uuid": "Necessary for uuid creation. You need ether symfony/polyfill-uuid or the uuid extension."
   },
   "autoload": {
     "psr-4": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "0018baab58a7a53da26f8805863e8240",
+    "content-hash": "039e4cc088dfb303f3ce5d5506b91a7c",
     "packages": [
         {
             "name": "doctrine/cache",
@@ -1796,88 +1796,6 @@
             ],
             "support": {
                 "source": "https://github.com/symfony/polyfill-mbstring/tree/v1.26.0"
-            },
-            "funding": [
-                {
-                    "url": "https://symfony.com/sponsor",
-                    "type": "custom"
-                },
-                {
-                    "url": "https://github.com/fabpot",
-                    "type": "github"
-                },
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
-                    "type": "tidelift"
-                }
-            ],
-            "time": "2022-05-24T11:49:31+00:00"
-        },
-        {
-            "name": "symfony/polyfill-uuid",
-            "version": "v1.26.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/symfony/polyfill-uuid.git",
-                "reference": "a41886c1c81dc075a09c71fe6db5b9d68c79de23"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-uuid/zipball/a41886c1c81dc075a09c71fe6db5b9d68c79de23",
-                "reference": "a41886c1c81dc075a09c71fe6db5b9d68c79de23",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=7.1"
-            },
-            "provide": {
-                "ext-uuid": "*"
-            },
-            "suggest": {
-                "ext-uuid": "For best performance"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-main": "1.26-dev"
-                },
-                "thanks": {
-                    "name": "symfony/polyfill",
-                    "url": "https://github.com/symfony/polyfill"
-                }
-            },
-            "autoload": {
-                "files": [
-                    "bootstrap.php"
-                ],
-                "psr-4": {
-                    "Symfony\\Polyfill\\Uuid\\": ""
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Grégoire Pineau",
-                    "email": "lyrixx@lyrixx.info"
-                },
-                {
-                    "name": "Symfony Community",
-                    "homepage": "https://symfony.com/contributors"
-                }
-            ],
-            "description": "Symfony polyfill for uuid functions",
-            "homepage": "https://symfony.com",
-            "keywords": [
-                "compatibility",
-                "polyfill",
-                "portable",
-                "uuid"
-            ],
-            "support": {
-                "source": "https://github.com/symfony/polyfill-uuid/tree/v1.26.0"
             },
             "funding": [
                 {
@@ -5718,6 +5636,88 @@
             "time": "2022-05-24T11:49:31+00:00"
         },
         {
+            "name": "symfony/polyfill-uuid",
+            "version": "v1.26.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/polyfill-uuid.git",
+                "reference": "a41886c1c81dc075a09c71fe6db5b9d68c79de23"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/polyfill-uuid/zipball/a41886c1c81dc075a09c71fe6db5b9d68c79de23",
+                "reference": "a41886c1c81dc075a09c71fe6db5b9d68c79de23",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.1"
+            },
+            "provide": {
+                "ext-uuid": "*"
+            },
+            "suggest": {
+                "ext-uuid": "For best performance"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "1.26-dev"
+                },
+                "thanks": {
+                    "name": "symfony/polyfill",
+                    "url": "https://github.com/symfony/polyfill"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "bootstrap.php"
+                ],
+                "psr-4": {
+                    "Symfony\\Polyfill\\Uuid\\": ""
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Grégoire Pineau",
+                    "email": "lyrixx@lyrixx.info"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony polyfill for uuid functions",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "compatibility",
+                "polyfill",
+                "portable",
+                "uuid"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/polyfill-uuid/tree/v1.26.0"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2022-05-24T11:49:31+00:00"
+        },
+        {
             "name": "symfony/process",
             "version": "v6.1.0",
             "source": {
@@ -6200,6 +6200,8 @@
     "platform": {
         "php": "8.0.*|8.1.*"
     },
-    "platform-dev": [],
+    "platform-dev": {
+        "ext-uuid": "^1.2"
+    },
     "plugin-api-version": "2.3.0"
 }


### PR DESCRIPTION
## Changes

- `symfony/polyfill-uuid` was required, but it has no value when the `uuid` extension is installed. Therefore, both are now part of `suggest` in the composer requirements.