### PR TITLE
Add template syntax to id lists

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,7 +178,7 @@ namespace App\ValueObject;
 
 use DigitalCraftsman\Ids\ValueObject\IdList;
 
-/** @psalm-immutable */
+/** @extends IdList<UserId> */
 final class UserIdList extends IdLIst
 {
     public static function handlesIdClass(): string

--- a/psalm.xml
+++ b/psalm.xml
@@ -6,6 +6,7 @@
 >
   <projectFiles>
     <directory name="src" />
+    <directory name="tests" />
     <ignoreFiles>
       <directory name="vendor" />
     </ignoreFiles>

--- a/src/ValueObject/IdList.php
+++ b/src/ValueObject/IdList.php
@@ -12,12 +12,22 @@ use DigitalCraftsman\Ids\ValueObject\Exception\IdListDoesNotContainId;
 use DigitalCraftsman\Ids\ValueObject\Exception\IdListIsNotEmpty;
 use DigitalCraftsman\Ids\ValueObject\Exception\IdListsMustBeEqual;
 
+/**
+ * @template T extends Id
+ * @psalm-consistent-constructor
+ *
+ * I think Psalm has an issue here as the constructor is final and the parameter is the template the child class will extend from, but I
+ * didn't find a solution without suppressing this psalm check.
+ *
+ * @psalm-suppress UnsafeGenericInstantiation
+ */
 abstract class IdList implements \Iterator, \Countable
 {
     /**
      * The id type has to be overwritten in the child class so that the correct id type is used in denormalization.
      *
      * @var array<int, Id>
+     * @psalm-var array<int, T>
      */
     public array $ids;
 
@@ -25,7 +35,10 @@ abstract class IdList implements \Iterator, \Countable
 
     // -- Construction
 
-    /** @param array<int, Id> $ids */
+    /**
+     * @param array<int, Id> $ids
+     * @psalm-param array<int, T> $ids
+     */
     final public function __construct(
         array $ids,
     ) {
@@ -35,7 +48,12 @@ abstract class IdList implements \Iterator, \Countable
         $this->ids = array_values($ids);
     }
 
-    /** @param array<int, Id> $ids */
+    /**
+     * @template TT of T
+     *
+     * @param array<int, Id> $ids
+     * @psalm-param array<int, TT> $ids
+     */
     final public static function fromIds(array $ids): static
     {
         return new static($ids);
@@ -71,6 +89,7 @@ abstract class IdList implements \Iterator, \Countable
 
     // -- Transformers
 
+    /** @psalm-param T $id */
     public function addId(Id $id): static
     {
         if ($this->containsId($id)) {
@@ -83,6 +102,7 @@ abstract class IdList implements \Iterator, \Countable
         return new static($ids);
     }
 
+    /** @psalm-param T $id */
     public function addIdWhenNotInList(Id $id): static
     {
         if ($this->containsId($id)) {
@@ -95,6 +115,7 @@ abstract class IdList implements \Iterator, \Countable
         return new static($ids);
     }
 
+    /** @psalm-param T $id */
     public function removeId(Id $id): static
     {
         $ids = array_filter(
@@ -105,6 +126,7 @@ abstract class IdList implements \Iterator, \Countable
         return new static($ids);
     }
 
+    /** @param static $idList */
     public function diff(self $idList): static
     {
         $idsNotInList = [];
@@ -127,6 +149,8 @@ abstract class IdList implements \Iterator, \Countable
     /**
      * Returns an id list of ids which exist in both lists. The order of the new list is the same as the list on which the function is
      * triggered from. The supplied list is only used for validation and not for order.
+     *
+     * @param static $idList
      */
     public function intersect(self $idList): static
     {
@@ -147,7 +171,7 @@ abstract class IdList implements \Iterator, \Countable
      *
      * @template R
      *
-     * @psalm-param impure-Closure(Id):R $mapFunction
+     * @psalm-param impure-Closure(T):R $mapFunction
      *
      * @return array<int, R>
      */
@@ -169,18 +193,21 @@ abstract class IdList implements \Iterator, \Countable
 
     // -- Accessors
 
+    /** @psalm-param T $id */
     public function containsId(Id $baseId): bool
     {
         /** @psalm-suppress ArgumentTypeCoercion */
         return $baseId->isExistingInList($this->ids);
     }
 
+    /** @psalm-param T $id */
     public function notContainsId(Id $baseId): bool
     {
         /** @psalm-suppress ArgumentTypeCoercion */
         return $baseId->isNotExistingInList($this->ids);
     }
 
+    /** @param static $idList */
     public function isEqualTo(self $idList): bool
     {
         if ($this->count() !== $idList->count()) {
@@ -196,6 +223,7 @@ abstract class IdList implements \Iterator, \Countable
         return true;
     }
 
+    /** @param static $idList */
     public function isNotEqualTo(self $idList): bool
     {
         return !$this->isEqualTo($idList);
@@ -211,6 +239,7 @@ abstract class IdList implements \Iterator, \Countable
         return $this->count() > 0;
     }
 
+    /** @param static $orderedList */
     public function isInSameOrder(self $orderedList): bool
     {
         $orderedListWithIdenticalIds = $orderedList->intersect($this);
@@ -223,6 +252,7 @@ abstract class IdList implements \Iterator, \Countable
         return true;
     }
 
+    /** @psalm-return T */
     public function idAtPosition(int $position): Id
     {
         return $this->ids[$position];
@@ -241,7 +271,11 @@ abstract class IdList implements \Iterator, \Countable
 
     // -- Guards
 
-    /** @throws IdListDoesNotContainId */
+    /**
+     * @psalm-param T $id
+     *
+     * @throws IdListDoesNotContainId
+     */
     public function mustContainId(Id $id): void
     {
         if ($this->notContainsId($id)) {
@@ -249,7 +283,11 @@ abstract class IdList implements \Iterator, \Countable
         }
     }
 
-    /** @throws IdListDoesContainId */
+    /**
+     * @psalm-param T $id
+     *
+     * @throws IdListDoesContainId
+     */
     public function mustNotContainId(Id $id): void
     {
         if ($this->containsId($id)) {
@@ -257,7 +295,11 @@ abstract class IdList implements \Iterator, \Countable
         }
     }
 
-    /** @throws IdListIsNotEmpty */
+    /**
+     * @psalm-param T $id
+     *
+     * @throws IdListIsNotEmpty
+     */
     public function mustBeEmpty(): void
     {
         if ($this->isNotEmpty()) {
@@ -266,7 +308,10 @@ abstract class IdList implements \Iterator, \Countable
     }
 
     /**
+     * @template TT of T
+     *
      * @param array<int, Id> $ids
+     * @psalm-param array<int, TT> $ids
      *
      * @throws DuplicateIds
      */
@@ -279,7 +324,10 @@ abstract class IdList implements \Iterator, \Countable
     }
 
     /**
+     * @template TT of T
+     *
      * @param array<int, Id> $ids
+     * @psalm-param array<int, TT> $ids
      *
      * @throws IdClassNotHandledInList
      */

--- a/src/ValueObject/IdList.php
+++ b/src/ValueObject/IdList.php
@@ -24,10 +24,9 @@ use DigitalCraftsman\Ids\ValueObject\Exception\IdListsMustBeEqual;
 abstract class IdList implements \Iterator, \Countable
 {
     /**
-     * The id type has to be overwritten in the child class so that the correct id type is used in denormalization.
-     *
      * @var array<int, Id>
      * @psalm-var array<int, T>
+     * @psalm-readonly
      */
     public array $ids;
 

--- a/src/ValueObject/IdList.php
+++ b/src/ValueObject/IdList.php
@@ -351,6 +351,7 @@ abstract class IdList implements \Iterator, \Countable
 
     // -- Iterator
 
+    /** @psalm-return T */
     public function current(): Id
     {
         return $this->ids[$this->index];

--- a/tests/Serializer/IdListNormalizerTest.php
+++ b/tests/Serializer/IdListNormalizerTest.php
@@ -73,6 +73,7 @@ final class IdListNormalizerTest extends TestCase
         ];
 
         // -- Act
+        /** @psalm-suppress InvalidScalarArgument */
         $normalizer->denormalize($invalidData, UserIdList::class);
     }
 

--- a/tests/Test/ValueObject/UserIdList.php
+++ b/tests/Test/ValueObject/UserIdList.php
@@ -6,15 +6,9 @@ namespace DigitalCraftsman\Ids\Test\ValueObject;
 
 use DigitalCraftsman\Ids\ValueObject\IdList;
 
-/** @psalm-immutable */
+/** @extends IdList<UserId> */
 final class UserIdList extends IdList
 {
-    /**
-     * @var array<int, UserId>
-     * @psalm-suppress NonInvariantDocblockPropertyType
-     */
-    public array $ids;
-
     public static function handlesIdClass(): string
     {
         return UserId::class;

--- a/tests/ValueObject/IdListTest.php
+++ b/tests/ValueObject/IdListTest.php
@@ -69,6 +69,7 @@ final class IdListTest extends TestCase
         $this->expectException(IdClassNotHandledInList::class);
 
         // -- Arrange & Act
+        /** @psalm-suppress InvalidArgument */
         new UserIdList([
             UserId::generateRandom(),
             UserId::generateRandom(),
@@ -538,6 +539,7 @@ final class IdListTest extends TestCase
         ];
 
         // -- Act
+        /** @var array<int, string> */
         $stringArray = $listWithAllIds->map(
             static fn (UserId $userId) => (string) $userId,
         );


### PR DESCRIPTION
## Changes

- Added template annotations to `IdList`.
- Enabled psalm validation for `tests` directory.

Resolves #10 