### PR TITLE
Add more methods for functional programming to id list

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -3065,16 +3065,16 @@
         },
         {
             "name": "friendsofphp/php-cs-fixer",
-            "version": "v3.9.4",
+            "version": "v3.9.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/FriendsOfPHP/PHP-CS-Fixer.git",
-                "reference": "093466b1c3ff3e3b469bdbc9827bb2362de6b2fa"
+                "reference": "4465d70ba776806857a1ac2a6f877e582445ff36"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/FriendsOfPHP/PHP-CS-Fixer/zipball/093466b1c3ff3e3b469bdbc9827bb2362de6b2fa",
-                "reference": "093466b1c3ff3e3b469bdbc9827bb2362de6b2fa",
+                "url": "https://api.github.com/repos/FriendsOfPHP/PHP-CS-Fixer/zipball/4465d70ba776806857a1ac2a6f877e582445ff36",
+                "reference": "4465d70ba776806857a1ac2a6f877e582445ff36",
                 "shasum": ""
             },
             "require": {
@@ -3142,7 +3142,7 @@
             "description": "A tool to automatically fix PHP code style",
             "support": {
                 "issues": "https://github.com/FriendsOfPHP/PHP-CS-Fixer/issues",
-                "source": "https://github.com/FriendsOfPHP/PHP-CS-Fixer/tree/v3.9.4"
+                "source": "https://github.com/FriendsOfPHP/PHP-CS-Fixer/tree/v3.9.5"
             },
             "funding": [
                 {
@@ -3150,7 +3150,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2022-07-15T21:04:49+00:00"
+            "time": "2022-07-22T08:43:51+00:00"
         },
         {
             "name": "myclabs/deep-copy",

--- a/src/ValueObject/IdList.php
+++ b/src/ValueObject/IdList.php
@@ -183,12 +183,10 @@ abstract class IdList implements \Iterator, \Countable
     /** @psalm-param impure-Closure(T) $filterFunction */
     public function filter(\Closure $filterFunction): static
     {
-        $filteredIds = array_filter(
+        return new static(array_filter(
             $this->ids,
             $filterFunction,
-        );
-
-        return new static($filteredIds);
+        ));
     }
 
     /** @psalm-param impure-Closure(T) $everyFunction */
@@ -213,6 +211,19 @@ abstract class IdList implements \Iterator, \Countable
         }
 
         return false;
+    }
+
+    /**
+     * @template R
+     *
+     * @psalm-param impure-Closure(R $carry, T):R $reduceFunction
+     * @psalm-param R $initial
+     *
+     * @return R
+     */
+    public function reduce(\Closure $reduceFunction, mixed $initial = null): mixed
+    {
+        return array_reduce($this->ids, $reduceFunction, $initial);
     }
 
     // -- Accessors

--- a/src/ValueObject/IdList.php
+++ b/src/ValueObject/IdList.php
@@ -180,6 +180,7 @@ abstract class IdList implements \Iterator, \Countable
         return array_values(array_map($mapFunction, $this->ids));
     }
 
+    /** @psalm-param impure-Closure(T) $filterFunction */
     public function filter(\Closure $filterFunction): static
     {
         $filteredIds = array_filter(
@@ -188,6 +189,30 @@ abstract class IdList implements \Iterator, \Countable
         );
 
         return new static($filteredIds);
+    }
+
+    /** @psalm-param impure-Closure(T) $everyFunction */
+    public function every(\Closure $everyFunction): bool
+    {
+        foreach ($this->ids as $id) {
+            if ($everyFunction($id) === false) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    /** @psalm-param impure-Closure(T) $someFunction */
+    public function some(\Closure $someFunction): bool
+    {
+        foreach ($this->ids as $id) {
+            if ($someFunction($id) === true) {
+                return true;
+            }
+        }
+
+        return false;
     }
 
     // -- Accessors

--- a/src/ValueObject/IdList.php
+++ b/src/ValueObject/IdList.php
@@ -163,6 +163,8 @@ abstract class IdList implements \Iterator, \Countable
         return new static($idsInList);
     }
 
+    // -- Functional programming
+
     /**
      * Psalm doesn't yet realize when a function is pure and when not. To prevent us from marking every single use by hand (which will
      * reduce the readability), we ignore the purity for now and will change the call here to pure-callable as soon as Psalm can handle
@@ -170,18 +172,18 @@ abstract class IdList implements \Iterator, \Countable
      *
      * @template R
      *
-     * @psalm-param impure-Closure(T):R $mapFunction
+     * @psalm-param callable(T):R $mapFunction
      *
      * @return array<int, R>
      */
-    public function map(\Closure $mapFunction): array
+    public function map(callable $mapFunction): array
     {
         /** @psalm-suppress ImpureFunctionCall */
         return array_values(array_map($mapFunction, $this->ids));
     }
 
-    /** @psalm-param impure-Closure(T) $filterFunction */
-    public function filter(\Closure $filterFunction): static
+    /** @psalm-param callable(T):bool $filterFunction */
+    public function filter(callable $filterFunction): static
     {
         return new static(array_filter(
             $this->ids,
@@ -189,8 +191,8 @@ abstract class IdList implements \Iterator, \Countable
         ));
     }
 
-    /** @psalm-param impure-Closure(T) $everyFunction */
-    public function every(\Closure $everyFunction): bool
+    /** @psalm-param callable(T):bool $everyFunction */
+    public function every(callable $everyFunction): bool
     {
         foreach ($this->ids as $id) {
             if ($everyFunction($id) === false) {
@@ -201,8 +203,8 @@ abstract class IdList implements \Iterator, \Countable
         return true;
     }
 
-    /** @psalm-param impure-Closure(T) $someFunction */
-    public function some(\Closure $someFunction): bool
+    /** @psalm-param callable(T):bool $someFunction */
+    public function some(callable $someFunction): bool
     {
         foreach ($this->ids as $id) {
             if ($someFunction($id) === true) {
@@ -216,12 +218,12 @@ abstract class IdList implements \Iterator, \Countable
     /**
      * @template R
      *
-     * @psalm-param impure-Closure(R $carry, T):R $reduceFunction
+     * @psalm-param callable(R $carry, T):R $reduceFunction
      * @psalm-param R $initial
      *
      * @return R
      */
-    public function reduce(\Closure $reduceFunction, mixed $initial = null): mixed
+    public function reduce(callable $reduceFunction, mixed $initial = null): mixed
     {
         return array_reduce($this->ids, $reduceFunction, $initial);
     }

--- a/tests/ValueObject/IdListTest.php
+++ b/tests/ValueObject/IdListTest.php
@@ -683,6 +683,44 @@ final class IdListTest extends TestCase
         self::assertFalse($noneIdIsIncluded);
     }
 
+    // -- Reduce
+
+    /**
+     * @test
+     * @covers ::reduce
+     */
+    public function id_list_reduce_works(): void
+    {
+        // -- Arrange
+        $idAnton = UserId::generateRandom();
+        $idMarkus = UserId::generateRandom();
+        $idPaul = UserId::generateRandom();
+        $idTom = UserId::generateRandom();
+
+        $amountsPerUser = [
+            (string) $idAnton => 20,
+            (string) $idMarkus => 30,
+            (string) $idPaul => 25,
+            (string) $idTom => 17,
+        ];
+
+        $listWithIdsOfAllUsers = UserIdList::fromIds([
+            $idAnton,
+            $idMarkus,
+            $idPaul,
+            $idTom,
+        ]);
+
+        // -- Act
+        $amountsOfAllUsers = $listWithIdsOfAllUsers->reduce(
+            static fn (int $carry, UserId $userId) => $carry + $amountsPerUser[(string) $userId],
+            0,
+        );
+
+        // -- Assert
+        self::assertSame(92, $amountsOfAllUsers);
+    }
+
     // -- Contains
 
     /**

--- a/tests/ValueObject/IdListTest.php
+++ b/tests/ValueObject/IdListTest.php
@@ -588,6 +588,101 @@ final class IdListTest extends TestCase
         self::assertSame($expectedArray, $filteredList->idsAsStringList());
     }
 
+    // -- Every
+
+    /**
+     * @test
+     * @covers ::every
+     */
+    public function id_list_every_works(): void
+    {
+        // -- Arrange
+        $idAnton = UserId::generateRandom();
+        $idMarkus = UserId::generateRandom();
+        $idPaul = UserId::generateRandom();
+        $idTom = UserId::generateRandom();
+
+        $idChris = UserId::generateRandom();
+
+        $listWithAllIdsOfGroupSparta = UserIdList::fromIds([
+            $idAnton,
+            $idMarkus,
+            $idPaul,
+            $idTom,
+        ]);
+
+        $listWithIdsThatAreAllInGroupSparta = UserIdList::fromIds([
+            $idAnton,
+            $idTom,
+        ]);
+
+        $listWithIdsThatAreNotAllInGroupSparta = UserIdList::fromIds([
+            $idAnton,
+            $idTom,
+            $idChris,
+        ]);
+
+        // -- Act
+        $everyIdIsIncluded = $listWithIdsThatAreAllInGroupSparta->every(
+            static fn (UserId $userId) => $listWithAllIdsOfGroupSparta->containsId($userId),
+        );
+        $notEveryIdIsIncluded = $listWithIdsThatAreNotAllInGroupSparta->every(
+            static fn (UserId $userId) => $listWithAllIdsOfGroupSparta->containsId($userId),
+        );
+
+        // -- Assert
+        self::assertTrue($everyIdIsIncluded);
+        self::assertFalse($notEveryIdIsIncluded);
+    }
+
+    // -- Some
+
+    /**
+     * @test
+     * @covers ::some
+     */
+    public function id_list_some_works(): void
+    {
+        // -- Arrange
+        $idAnton = UserId::generateRandom();
+        $idMarkus = UserId::generateRandom();
+        $idPaul = UserId::generateRandom();
+        $idTom = UserId::generateRandom();
+
+        $idChris = UserId::generateRandom();
+        $idQuirin = UserId::generateRandom();
+
+        $listWithAllIdsOfGroupSparta = UserIdList::fromIds([
+            $idAnton,
+            $idMarkus,
+            $idPaul,
+            $idTom,
+        ]);
+
+        $listWithIdsThatContainSomeOfSpartaGroup = UserIdList::fromIds([
+            $idAnton,
+            $idTom,
+            $idChris,
+        ]);
+
+        $listWithIdsThatContainNoneOfSpartaGroup = UserIdList::fromIds([
+            $idChris,
+            $idQuirin,
+        ]);
+
+        // -- Act
+        $someIdIsIncluded = $listWithIdsThatContainSomeOfSpartaGroup->some(
+            static fn (UserId $userId) => $listWithAllIdsOfGroupSparta->containsId($userId),
+        );
+        $noneIdIsIncluded = $listWithIdsThatContainNoneOfSpartaGroup->some(
+            static fn (UserId $userId) => $listWithAllIdsOfGroupSparta->containsId($userId),
+        );
+
+        // -- Assert
+        self::assertTrue($someIdIsIncluded);
+        self::assertFalse($noneIdIsIncluded);
+    }
+
     // -- Contains
 
     /**


### PR DESCRIPTION
## Changes

- New `every` method for `IdList`.
- New `some` method for `IdList`.
- New `reduce` method for `IdList`.
- Switched from `\Closure` to `callable` for parameters (compatible with existing) as Psalm understands it better.