### PR TITLE
Prepare first release

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,6 +1,7 @@
 .docker export-ignore
 .github export-ignore
 .env.example export-ignore
+docs export-ignore
 tests export-ignore
 .editorconfig export-ignore
 .gitattributes export-ignore

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## 0.1.0
+
+- Initial release

--- a/README.md
+++ b/README.md
@@ -4,7 +4,8 @@ A Symfony bundle to work with id and id list value objects in Symfony. It includ
 
 As it's a central part of an application, it's tested thoroughly.
 
-[![Latest Unstable Version](http://poser.pugx.org/digital-craftsman/ids/v/unstable)](https://packagist.org/packages/digital-craftsman/ids)
+[![Latest Stable Version](http://poser.pugx.org/digital-craftsman/ids/v)](https://packagist.org/packages/digital-craftsman/ids)
+[![PHP Version Require](http://poser.pugx.org/digital-craftsman/ids/require/php)](https://packagist.org/packages/digital-craftsman/ids)
 [![codecov](https://codecov.io/gh/digital-craftsman-de/ids/branch/main/graph/badge.svg?token=BL0JKZYLBG)](https://codecov.io/gh/digital-craftsman-de/ids)
 [![Total Downloads](http://poser.pugx.org/digital-craftsman/ids/downloads)](https://packagist.org/packages/digital-craftsman/ids)
 [![License](http://poser.pugx.org/digital-craftsman/ids/license)](https://packagist.org/packages/digital-craftsman/ids)

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Install package through composer:
 composer require digital-craftsman/ids
 ```
 
-Additionally, you ether need the [`uuid` PHP extension](https://pecl.php.net/package/uuid) installed or the polyfill `symfony/polyfill-uuid` as part of your composer requirements. Using the `uuid` extension is around twice as fast when handling thousands of ids in one request.
+It's recommended that you install the [`uuid` PHP extension](https://pecl.php.net/package/uuid) for better performance of id creation and validation.  `symfony/polyfill-uuid` is used as a fallback. You can [prevent installing the polyfill](./docs/prevent-polyfill-usage.md) when you've installed the PHP extension.
 
 ## Working with ids
 

--- a/README.md
+++ b/README.md
@@ -20,6 +20,8 @@ composer require digital-craftsman/ids
 
 It's recommended that you install the [`uuid` PHP extension](https://pecl.php.net/package/uuid) for better performance of id creation and validation.  `symfony/polyfill-uuid` is used as a fallback. You can [prevent installing the polyfill](./docs/prevent-polyfill-usage.md) when you've installed the PHP extension.
 
+> ⚠️ This bundle can be used (and is being used) in production, but hasn't reached version 1.0 yet. Therefore, there will be breaking changes between minor versions. I'd recommend that you require the bundle only with the current minor version like `composer require digital-craftsman/ids:0.1.*`. Breaking changes are described in the releases and [the changelog](./CHANGELOG.md). Updates are described in the [upgrade guide](./UPGRADE.md).
+
 ## Working with ids
 
 ### Creating a new id

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -1,0 +1,3 @@
+# Upgrade guide
+
+No upgrades necessary yet.

--- a/composer.json
+++ b/composer.json
@@ -6,18 +6,16 @@
     "php": "8.0.*|8.1.*",
     "symfony/framework-bundle": "^5.4|^6.0",
     "symfony/serializer": "^5.4|^6.0",
-    "doctrine/dbal": "^2.13.8|^3.3.6"
+    "doctrine/dbal": "^2.13.8|^3.3.6",
+    "symfony/polyfill-uuid": "^1.26"
   },
   "require-dev": {
     "vimeo/psalm": "^4.12",
     "friendsofphp/php-cs-fixer": "^3.3",
-    "phpunit/phpunit": "^9.5",
-    "symfony/polyfill-uuid": "^1.26",
-    "ext-uuid": "^1.2"
+    "phpunit/phpunit": "^9.5"
   },
   "suggest": {
-    "ext-uuid": "Necessary for uuid creation. You need ether the uuid extension or symfony/polyfill-uuid.",
-    "symfony/polyfill-uuid": "Necessary for uuid creation. You need ether symfony/polyfill-uuid or the uuid extension."
+    "ext-uuid": "Improves performance of id creation and validation. symfony/polyfill-uuid is used as a fallback."
   },
   "autoload": {
     "psr-4": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "039e4cc088dfb303f3ce5d5506b91a7c",
+    "content-hash": "0018baab58a7a53da26f8805863e8240",
     "packages": [
         {
             "name": "doctrine/cache",
@@ -1796,6 +1796,88 @@
             ],
             "support": {
                 "source": "https://github.com/symfony/polyfill-mbstring/tree/v1.26.0"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2022-05-24T11:49:31+00:00"
+        },
+        {
+            "name": "symfony/polyfill-uuid",
+            "version": "v1.26.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/polyfill-uuid.git",
+                "reference": "a41886c1c81dc075a09c71fe6db5b9d68c79de23"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/polyfill-uuid/zipball/a41886c1c81dc075a09c71fe6db5b9d68c79de23",
+                "reference": "a41886c1c81dc075a09c71fe6db5b9d68c79de23",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.1"
+            },
+            "provide": {
+                "ext-uuid": "*"
+            },
+            "suggest": {
+                "ext-uuid": "For best performance"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "1.26-dev"
+                },
+                "thanks": {
+                    "name": "symfony/polyfill",
+                    "url": "https://github.com/symfony/polyfill"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "bootstrap.php"
+                ],
+                "psr-4": {
+                    "Symfony\\Polyfill\\Uuid\\": ""
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Grégoire Pineau",
+                    "email": "lyrixx@lyrixx.info"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony polyfill for uuid functions",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "compatibility",
+                "polyfill",
+                "portable",
+                "uuid"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/polyfill-uuid/tree/v1.26.0"
             },
             "funding": [
                 {
@@ -5636,88 +5718,6 @@
             "time": "2022-05-24T11:49:31+00:00"
         },
         {
-            "name": "symfony/polyfill-uuid",
-            "version": "v1.26.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/symfony/polyfill-uuid.git",
-                "reference": "a41886c1c81dc075a09c71fe6db5b9d68c79de23"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-uuid/zipball/a41886c1c81dc075a09c71fe6db5b9d68c79de23",
-                "reference": "a41886c1c81dc075a09c71fe6db5b9d68c79de23",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=7.1"
-            },
-            "provide": {
-                "ext-uuid": "*"
-            },
-            "suggest": {
-                "ext-uuid": "For best performance"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-main": "1.26-dev"
-                },
-                "thanks": {
-                    "name": "symfony/polyfill",
-                    "url": "https://github.com/symfony/polyfill"
-                }
-            },
-            "autoload": {
-                "files": [
-                    "bootstrap.php"
-                ],
-                "psr-4": {
-                    "Symfony\\Polyfill\\Uuid\\": ""
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Grégoire Pineau",
-                    "email": "lyrixx@lyrixx.info"
-                },
-                {
-                    "name": "Symfony Community",
-                    "homepage": "https://symfony.com/contributors"
-                }
-            ],
-            "description": "Symfony polyfill for uuid functions",
-            "homepage": "https://symfony.com",
-            "keywords": [
-                "compatibility",
-                "polyfill",
-                "portable",
-                "uuid"
-            ],
-            "support": {
-                "source": "https://github.com/symfony/polyfill-uuid/tree/v1.26.0"
-            },
-            "funding": [
-                {
-                    "url": "https://symfony.com/sponsor",
-                    "type": "custom"
-                },
-                {
-                    "url": "https://github.com/fabpot",
-                    "type": "github"
-                },
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
-                    "type": "tidelift"
-                }
-            ],
-            "time": "2022-05-24T11:49:31+00:00"
-        },
-        {
             "name": "symfony/process",
             "version": "v6.1.0",
             "source": {
@@ -6200,8 +6200,6 @@
     "platform": {
         "php": "8.0.*|8.1.*"
     },
-    "platform-dev": {
-        "ext-uuid": "^1.2"
-    },
+    "platform-dev": [],
     "plugin-api-version": "2.3.0"
 }

--- a/docs/prevent-polyfill-usage.md
+++ b/docs/prevent-polyfill-usage.md
@@ -1,6 +1,6 @@
 # Remove polyfill
 
-When you've installed the `uuid` extension for PHP, there is no need for installing and loading the `symfony/polyfill-uuid` package. To remove it from the installed and loaded packages, simply add it to your `replace` list in your `composer.json` file like the following:
+When you've installed the `uuid` PHP extension, there is no reason to install and load the `symfony/polyfill-uuid` package. To remove it from the installed and loaded packages, simply add it to your `replace` list in your `composer.json` file like the following:
 
 ```json
 {

--- a/docs/prevent-polyfill-usage.md
+++ b/docs/prevent-polyfill-usage.md
@@ -9,3 +9,13 @@ When you've installed the `uuid` PHP extension, there is no reason to install an
   }
 }
 ```
+
+Just make sure you've added `ext-uuid` to your `composer.json` requirements like the following:
+
+```json
+{
+  "require": {
+    "ext-uuid": "*"
+  }
+}
+```

--- a/docs/prevent-polyfill-usage.md
+++ b/docs/prevent-polyfill-usage.md
@@ -10,7 +10,7 @@ When you've installed the `uuid` PHP extension, there is no reason to install an
 }
 ```
 
-Just make sure you've added `ext-uuid` to your `composer.json` requirements like the following:
+Just make sure to add `ext-uuid` to your `composer.json` requirements like the following:
 
 ```json
 {

--- a/docs/prevent-polyfill-usage.md
+++ b/docs/prevent-polyfill-usage.md
@@ -1,0 +1,11 @@
+# Remove polyfill
+
+When you've installed the `uuid` extension for PHP, there is no need for installing and loading the `symfony/polyfill-uuid` package. To remove it from the installed and loaded packages, simply add it to your `replace` list in your `composer.json` file like the following:
+
+```json
+{
+  "replace": {
+    "symfony/polyfill-uuid": "*"
+  }
+}
+```


### PR DESCRIPTION
## Changes

- Requires `symfony/polyfill-uuid` and describe how you can disable it, if the `uuid` extension is installed.
- Added new badges.
- Added warning about breaks in minor versions.