### PR TITLE
Fix usage of id subclass in list and use id list as parameter for isExistingInList

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 0.2.0
+
+- **[Breaking change](./UPGRADE.md#id-list-parameter-for-isexistinginlist-and-isnotexistinginlist)**: The methods `isExistingInList` and `isNotExistingInList` now expect an id list as parameter instead of an array of ids.
+- Id list now supports ids of id subclass.
+
 ## 0.1.0
 
 - Initial release

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ composer require digital-craftsman/ids
 
 It's recommended that you install the [`uuid` PHP extension](https://pecl.php.net/package/uuid) for better performance of id creation and validation.  `symfony/polyfill-uuid` is used as a fallback. You can [prevent installing the polyfill](./docs/prevent-polyfill-usage.md) when you've installed the PHP extension.
 
-> ⚠️ This bundle can be used (and is being used) in production, but hasn't reached version 1.0 yet. Therefore, there will be breaking changes between minor versions. I'd recommend that you require the bundle only with the current minor version like `composer require digital-craftsman/ids:0.1.*`. Breaking changes are described in the releases and [the changelog](./CHANGELOG.md). Updates are described in the [upgrade guide](./UPGRADE.md).
+> ⚠️ This bundle can be used (and is being used) in production, but hasn't reached version 1.0 yet. Therefore, there will be breaking changes between minor versions. I'd recommend that you require the bundle only with the current minor version like `composer require digital-craftsman/ids:0.2.*`. Breaking changes are described in the releases and [the changelog](./CHANGELOG.md). Updates are described in the [upgrade guide](./UPGRADE.md).
 
 ## Working with ids
 

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -1,3 +1,31 @@
 # Upgrade guide
 
-No upgrades necessary yet.
+## From 0.1.* to 0.2.0
+
+### Id list parameter for `isExistingInList` and `isNotExistingInList`
+
+Previously the parameter was `array<int, Id> $list`. Now it's `IdList $list`.
+
+Before:
+
+```php
+$idsOfUsersWithAccess = [
+    $project->idOfUserWithAccess,
+    $company->idOfUserWithAccess,
+];
+
+if ($command->userId->isExistingInList($idsOfUsersWithAccess)) {
+    ...
+```
+
+After:
+
+```php
+$idsOfUsersWithAccess = new UserIdList([
+    $project->idOfUserWithAccess,
+    $company->idOfUserWithAccess,
+]);
+
+if ($command->userId->isExistingInList($idsOfUsersWithAccess)) {
+    ...
+```

--- a/src/ValueObject/Id.php
+++ b/src/ValueObject/Id.php
@@ -51,18 +51,14 @@ abstract class Id implements \Stringable
     }
 
     /**
-     * Comparison without strict to made with @see __toString(). We use this method so we don't use it in strict mode on
-     * accident somewhere.
-     *
-     * @param array<int, static> $list
+     * Comparison without strict to made with @see __toString(). We use this method so we don't use it in strict mode on accident somewhere.
      */
-    public function isExistingInList(array $list): bool
+    public function isExistingInList(IdList $list): bool
     {
-        return in_array($this, $list, false);
+        return in_array($this, $list->ids, false);
     }
 
-    /** @param array<int, static> $list */
-    public function isNotExistingInList(array $list): bool
+    public function isNotExistingInList(IdList $list): bool
     {
         return !$this->isExistingInList($list);
     }

--- a/src/ValueObject/IdList.php
+++ b/src/ValueObject/IdList.php
@@ -84,6 +84,11 @@ abstract class IdList implements \Iterator, \Countable
 
     // -- Configuration
 
+    /**
+     * @template TT of T
+     *
+     * @return class-string<TT>
+     */
     abstract public static function handlesIdClass(): string;
 
     // -- Transformers
@@ -233,15 +238,13 @@ abstract class IdList implements \Iterator, \Countable
     /** @psalm-param T $id */
     public function containsId(Id $baseId): bool
     {
-        /** @psalm-suppress ArgumentTypeCoercion */
-        return $baseId->isExistingInList($this->ids);
+        return $baseId->isExistingInList($this);
     }
 
     /** @psalm-param T $id */
     public function notContainsId(Id $baseId): bool
     {
-        /** @psalm-suppress ArgumentTypeCoercion */
-        return $baseId->isNotExistingInList($this->ids);
+        return $baseId->isNotExistingInList($this);
     }
 
     /** @param static $idList */
@@ -372,7 +375,7 @@ abstract class IdList implements \Iterator, \Countable
     {
         $idClass = static::handlesIdClass();
         foreach ($ids as $id) {
-            if ($id::class !== $idClass) {
+            if (!$id instanceof $idClass) {
                 throw new IdClassNotHandledInList(static::class, $id::class);
             }
         }

--- a/tests/Test/ValueObject/AdminId.php
+++ b/tests/Test/ValueObject/AdminId.php
@@ -4,9 +4,7 @@ declare(strict_types=1);
 
 namespace DigitalCraftsman\Ids\Test\ValueObject;
 
-use DigitalCraftsman\Ids\ValueObject\Id;
-
 /** @psalm-immutable */
-class UserId extends Id
+final class AdminId extends UserId
 {
 }

--- a/tests/Test/ValueObject/InstructorId.php
+++ b/tests/Test/ValueObject/InstructorId.php
@@ -4,9 +4,7 @@ declare(strict_types=1);
 
 namespace DigitalCraftsman\Ids\Test\ValueObject;
 
-use DigitalCraftsman\Ids\ValueObject\Id;
-
 /** @psalm-immutable */
-class UserId extends Id
+final class InstructorId extends UserId
 {
 }

--- a/tests/ValueObject/IdListTest.php
+++ b/tests/ValueObject/IdListTest.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace DigitalCraftsman\Ids\ValueObject;
 
+use DigitalCraftsman\Ids\Test\ValueObject\AdminId;
+use DigitalCraftsman\Ids\Test\ValueObject\InstructorId;
 use DigitalCraftsman\Ids\Test\ValueObject\ProjectId;
 use DigitalCraftsman\Ids\Test\ValueObject\UserId;
 use DigitalCraftsman\Ids\Test\ValueObject\UserIdList;
@@ -33,6 +35,23 @@ final class IdListTest extends TestCase
             UserId::generateRandom(),
             UserId::generateRandom(),
             UserId::generateRandom(),
+        ]);
+    }
+
+    /**
+     * @test
+     * @covers ::__construct
+     * @covers ::mustOnlyContainIdsOfHandledClass
+     * @doesNotPerformAssertions
+     */
+    public function id_list_construction_works_with_ids_of_subclass(): void
+    {
+        // -- Arrange & Act
+        new UserIdList([
+            UserId::generateRandom(),
+            UserId::generateRandom(),
+            InstructorId::generateRandom(),
+            AdminId::generateRandom(),
         ]);
     }
 
@@ -539,7 +558,7 @@ final class IdListTest extends TestCase
         ];
 
         // -- Act
-        /** @var array<int, string> */
+        /** @var array<int, string> $stringArray */
         $stringArray = $listWithAllIds->map(
             static fn (UserId $userId) => (string) $userId,
         );

--- a/tests/ValueObject/IdTest.php
+++ b/tests/ValueObject/IdTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace DigitalCraftsman\Ids\ValueObject;
 
 use DigitalCraftsman\Ids\Test\ValueObject\UserId;
+use DigitalCraftsman\Ids\Test\ValueObject\UserIdList;
 use DigitalCraftsman\Ids\ValueObject\Exception\IdEqual;
 use DigitalCraftsman\Ids\ValueObject\Exception\IdNotEqual;
 use DigitalCraftsman\Ids\ValueObject\Exception\InvalidId;
@@ -85,19 +86,19 @@ final class IdTest extends TestCase
 
         $userIdNotInList = UserId::generateRandom();
 
-        $listOfUserIdsIncludingSameInstance = [
+        $listOfUserIdsIncludingSameInstance = new UserIdList([
             $userIdToSearch,
             $userId1,
             $userId2,
-        ];
+        ]);
 
         $copyOfStringValue = UserId::fromString((string) $userIdToSearch);
 
-        $listOfUserIdsIncludingEqualInstance = [
+        $listOfUserIdsIncludingEqualInstance = new UserIdList([
             $copyOfStringValue,
             $userId1,
             $userId2,
-        ];
+        ]);
 
         // -- Act & Assert
         self::assertTrue($userIdToSearch->isExistingInList($listOfUserIdsIncludingSameInstance));
@@ -119,10 +120,10 @@ final class IdTest extends TestCase
         $userId1 = UserId::generateRandom();
         $userId2 = UserId::generateRandom();
 
-        $listOfUserIdsWithoutIdToSearch = [
+        $listOfUserIdsWithoutIdToSearch = new UserIdList([
             $userId1,
             $userId2,
-        ];
+        ]);
 
         // -- Act & Assert
         self::assertFalse($userIdToSearch->isExistingInList($listOfUserIdsWithoutIdToSearch));


### PR DESCRIPTION
## Changes

- A subclass of an id can now also be used in an id list.
- The `isExistingInList` and `isNotExistingInList` now use an id list as parameter instead of an array of ids.