### PR TITLE
Remove isExistingInList methods and improve comments and naming

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.3.0
+
+- **[Breaking change](./UPGRADE.md#removed-methods-isexistinginlist-and-isnotexistinginlist)**: The methods `isExistingInList` and `isNotExistingInList` have been removed. The `containsId` method of the list class must be used instead.
+
 ## 0.2.0
 
 - **[Breaking change](./UPGRADE.md#id-list-parameter-for-isexistinginlist-and-isnotexistinginlist)**: The methods `isExistingInList` and `isNotExistingInList` now expect an id list as parameter instead of an array of ids.

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ composer require digital-craftsman/ids
 
 It's recommended that you install the [`uuid` PHP extension](https://pecl.php.net/package/uuid) for better performance of id creation and validation.  `symfony/polyfill-uuid` is used as a fallback. You can [prevent installing the polyfill](./docs/prevent-polyfill-usage.md) when you've installed the PHP extension.
 
-> ⚠️ This bundle can be used (and is being used) in production, but hasn't reached version 1.0 yet. Therefore, there will be breaking changes between minor versions. I'd recommend that you require the bundle only with the current minor version like `composer require digital-craftsman/ids:0.2.*`. Breaking changes are described in the releases and [the changelog](./CHANGELOG.md). Updates are described in the [upgrade guide](./UPGRADE.md).
+> ⚠️ This bundle can be used (and is being used) in production, but hasn't reached version 1.0 yet. Therefore, there will be breaking changes between minor versions. I'd recommend that you require the bundle only with the current minor version like `composer require digital-craftsman/ids:0.3.*`. Breaking changes are described in the releases and [the changelog](./CHANGELOG.md). Updates are described in the [upgrade guide](./UPGRADE.md).
 
 ## Working with ids
 

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -1,5 +1,35 @@
 # Upgrade guide
 
+## From 0.2.* to 0.3.0
+
+### Removed methods `isExistingInList` and `isNotExistingInList`
+
+The owning side for this method is the list, so it doesn't make sense to have it on the id. There already is a `containsId` method on the list which must be used instead.
+
+Before:
+
+```php
+$idsOfUsersWithAccess = new UserIdList([
+    $project->idOfUserWithAccess,
+    $company->idOfUserWithAccess,
+]);
+
+if ($command->userId->isExistingInList($idsOfUsersWithAccess)) {
+    ...
+```
+
+After:
+
+```php
+$idsOfUsersWithAccess = new UserIdList([
+    $project->idOfUserWithAccess,
+    $company->idOfUserWithAccess,
+]);
+
+if ($idsOfUsersWithAccess->containsId($command->userId)) {
+    ...
+```
+
 ## From 0.1.* to 0.2.0
 
 ### Id list parameter for `isExistingInList` and `isNotExistingInList`

--- a/src/ValueObject/Id.php
+++ b/src/ValueObject/Id.php
@@ -50,19 +50,6 @@ abstract class Id implements \Stringable
         return $this->value !== $id->value;
     }
 
-    /**
-     * Comparison without strict to made with @see __toString(). We use this method so we don't use it in strict mode on accident somewhere.
-     */
-    public function isExistingInList(IdList $list): bool
-    {
-        return in_array($this, $list->ids, false);
-    }
-
-    public function isNotExistingInList(IdList $list): bool
-    {
-        return !$this->isExistingInList($list);
-    }
-
     // Guards
 
     /** @throws IdNotEqual */

--- a/src/ValueObject/IdList.php
+++ b/src/ValueObject/IdList.php
@@ -145,6 +145,7 @@ abstract class IdList implements \Iterator, \Countable
             }
         }
 
+        // The sort value is used explicitly to convey the importance of sorting by string cast.
         $uniqueIds = array_unique($idsNotInList, SORT_STRING);
 
         return new static($uniqueIds);
@@ -236,15 +237,16 @@ abstract class IdList implements \Iterator, \Countable
     // -- Accessors
 
     /** @psalm-param T $id */
-    public function containsId(Id $baseId): bool
+    public function containsId(Id $id): bool
     {
-        return $baseId->isExistingInList($this);
+        // The strict value is used explicitly to convey the importance of not validating strictly. It has to use a string cast.
+        return in_array($id, $this->ids, false);
     }
 
     /** @psalm-param T $id */
-    public function notContainsId(Id $baseId): bool
+    public function notContainsId(Id $id): bool
     {
-        return $baseId->isNotExistingInList($this);
+        return !$this->containsId($id);
     }
 
     /** @param static $idList */

--- a/tests/ValueObject/IdTest.php
+++ b/tests/ValueObject/IdTest.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace DigitalCraftsman\Ids\ValueObject;
 
 use DigitalCraftsman\Ids\Test\ValueObject\UserId;
-use DigitalCraftsman\Ids\Test\ValueObject\UserIdList;
 use DigitalCraftsman\Ids\ValueObject\Exception\IdEqual;
 use DigitalCraftsman\Ids\ValueObject\Exception\IdNotEqual;
 use DigitalCraftsman\Ids\ValueObject\Exception\InvalidId;
@@ -67,66 +66,6 @@ final class IdTest extends TestCase
 
         // -- Act & Assert
         self::assertTrue($userId1->isNotEqualTo($userId2));
-    }
-
-    /**
-     * @test
-     * @covers ::isExistingInList
-     * @covers ::isNotExistingInList
-     */
-    public function user_id_is_existing_in_list(): void
-    {
-        // -- Arrange
-        $uuid = uuid_create();
-
-        $userIdToSearch = new UserId($uuid);
-
-        $userId1 = UserId::generateRandom();
-        $userId2 = UserId::generateRandom();
-
-        $userIdNotInList = UserId::generateRandom();
-
-        $listOfUserIdsIncludingSameInstance = new UserIdList([
-            $userIdToSearch,
-            $userId1,
-            $userId2,
-        ]);
-
-        $copyOfStringValue = UserId::fromString((string) $userIdToSearch);
-
-        $listOfUserIdsIncludingEqualInstance = new UserIdList([
-            $copyOfStringValue,
-            $userId1,
-            $userId2,
-        ]);
-
-        // -- Act & Assert
-        self::assertTrue($userIdToSearch->isExistingInList($listOfUserIdsIncludingSameInstance));
-        self::assertTrue($userIdToSearch->isExistingInList($listOfUserIdsIncludingEqualInstance));
-        self::assertTrue($userIdNotInList->isNotExistingInList($listOfUserIdsIncludingEqualInstance));
-    }
-
-    /**
-     * @test
-     * @covers ::isExistingInList
-     */
-    public function user_id_is_not_existing_in_list(): void
-    {
-        // -- Arrange
-        $uuid = uuid_create();
-
-        $userIdToSearch = new UserId($uuid);
-
-        $userId1 = UserId::generateRandom();
-        $userId2 = UserId::generateRandom();
-
-        $listOfUserIdsWithoutIdToSearch = new UserIdList([
-            $userId1,
-            $userId2,
-        ]);
-
-        // -- Act & Assert
-        self::assertFalse($userIdToSearch->isExistingInList($listOfUserIdsWithoutIdToSearch));
     }
 
     /**


### PR DESCRIPTION
## Changes

- Removed `isExistingInList` and `isNotExistingInList` as they are just the inverse side of `containsId` and `notContainsId` of the list class.
- Improve comments and naming.