### PR TITLE
Swap IdList implementation of \Iterator to \IteratorAggregate

### DIFF
--- a/src/ValueObject/IdList.php
+++ b/src/ValueObject/IdList.php
@@ -21,7 +21,7 @@ use DigitalCraftsman\Ids\ValueObject\Exception\IdListsMustBeEqual;
  *
  * @psalm-suppress UnsafeGenericInstantiation
  */
-abstract class IdList implements \Iterator, \Countable
+abstract class IdList implements \IteratorAggregate, \Countable
 {
     /**
      * @var array<int, Id>
@@ -29,8 +29,6 @@ abstract class IdList implements \Iterator, \Countable
      * @psalm-readonly
      */
     public array $ids;
-
-    public int $index = 0;
 
     // -- Construction
 
@@ -393,31 +391,11 @@ abstract class IdList implements \Iterator, \Countable
 
     // -- Iterator
 
-    /** @psalm-return T */
-    public function current(): Id
+    public function getIterator(): \Iterator
     {
-        return $this->ids[$this->index];
+        return new \ArrayIterator($this->ids);
     }
 
-    public function next(): void
-    {
-        ++$this->index;
-    }
-
-    public function key(): int
-    {
-        return $this->index;
-    }
-
-    public function rewind(): void
-    {
-        $this->index = 0;
-    }
-
-    public function valid(): bool
-    {
-        return array_key_exists($this->index, $this->ids);
-    }
 
     // -- Countable
 

--- a/src/ValueObject/IdList.php
+++ b/src/ValueObject/IdList.php
@@ -389,13 +389,12 @@ abstract class IdList implements \IteratorAggregate, \Countable
         }
     }
 
-    // -- Iterator
+    // -- Iterator aggregate
 
     public function getIterator(): \Iterator
     {
         return new \ArrayIterator($this->ids);
     }
-
 
     // -- Countable
 

--- a/tests/ValueObject/IdListTest.php
+++ b/tests/ValueObject/IdListTest.php
@@ -927,11 +927,7 @@ final class IdListTest extends TestCase
 
     /**
      * @test
-     * @covers ::current
-     * @covers ::next
-     * @covers ::key
-     * @covers ::rewind
-     * @covers ::valid
+     * @covers ::getIterator
      */
     public function id_list_iteration_works(): void
     {
@@ -941,6 +937,12 @@ final class IdListTest extends TestCase
         $idPaul = UserId::generateRandom();
 
         $idList = new UserIdList([
+            $idAnton,
+            $idMarkus,
+            $idPaul,
+        ]);
+
+        $duplicatedIdList = new UserIdList([
             $idAnton,
             $idMarkus,
             $idPaul,
@@ -965,15 +967,14 @@ final class IdListTest extends TestCase
 
         // -- Assert
         self::assertSame($expectedString, $concatenatedIds);
+
+        // Id list is equal after iteration
+        self::assertEquals($duplicatedIdList, $idList);
     }
 
     /**
      * @test
-     * @covers ::current
-     * @covers ::next
-     * @covers ::key
-     * @covers ::rewind
-     * @covers ::valid
+     * @covers ::getIterator
      */
     public function id_list_works_with_gaps_in_input_list(): void
     {


### PR DESCRIPTION
To avoid leaking internal `$index` state, incase of e.g: unit test assertions.