### PR TITLE
Add id list optimization

### DIFF
--- a/src/Serializer/IdNormalizer.php
+++ b/src/Serializer/IdNormalizer.php
@@ -30,6 +30,7 @@ final class IdNormalizer implements NormalizerInterface, DenormalizerInterface, 
 
     /**
      * @param ?string $data
+     *
      * @psalm-param class-string<Id> $type
      */
     public function denormalize($data, $type, $format = null, array $context = []): ?Id

--- a/src/ValueObject/IdList.php
+++ b/src/ValueObject/IdList.php
@@ -14,6 +14,7 @@ use DigitalCraftsman\Ids\ValueObject\Exception\IdListsMustBeEqual;
 
 /**
  * @template T extends Id
+ *
  * @psalm-consistent-constructor
  *
  * I think Psalm has an issue here as the constructor is final and the parameter is the template the child class will extend from, but I
@@ -25,7 +26,9 @@ abstract class IdList implements \IteratorAggregate, \Countable
 {
     /**
      * @var array<int, Id>
+     *
      * @psalm-var array<int, T>
+     *
      * @psalm-readonly
      */
     public array $ids;
@@ -34,6 +37,7 @@ abstract class IdList implements \IteratorAggregate, \Countable
 
     /**
      * @param array<int, Id> $ids
+     *
      * @psalm-param array<int, T> $ids
      */
     final public function __construct(
@@ -49,6 +53,7 @@ abstract class IdList implements \IteratorAggregate, \Countable
      * @template TT of T
      *
      * @param array<int, Id> $ids
+     *
      * @psalm-param array<int, TT> $ids
      */
     final public static function fromIds(array $ids): static
@@ -351,6 +356,7 @@ abstract class IdList implements \IteratorAggregate, \Countable
      * @template TT of T
      *
      * @param array<int, Id> $ids
+     *
      * @psalm-param array<int, TT> $ids
      *
      * @throws DuplicateIds
@@ -367,6 +373,7 @@ abstract class IdList implements \IteratorAggregate, \Countable
      * @template TT of T
      *
      * @param array<int, Id> $ids
+     *
      * @psalm-param array<int, TT> $ids
      *
      * @throws IdClassNotHandledInList

--- a/src/ValueObject/IdList.php
+++ b/src/ValueObject/IdList.php
@@ -96,7 +96,7 @@ abstract class IdList implements \IteratorAggregate, \Countable
 
     // -- Transformers
 
-    /** @psalm-param T $id */
+    /** @param T $id */
     public function addId(Id $id): static
     {
         if ($this->containsId($id)) {
@@ -109,7 +109,7 @@ abstract class IdList implements \IteratorAggregate, \Countable
         return new static($ids);
     }
 
-    /** @psalm-param T $id */
+    /** @param T $id */
     public function addIdWhenNotInList(Id $id): static
     {
         if ($this->containsId($id)) {
@@ -122,7 +122,7 @@ abstract class IdList implements \IteratorAggregate, \Countable
         return new static($ids);
     }
 
-    /** @psalm-param T $id */
+    /** @param T $id */
     public function removeId(Id $id): static
     {
         $ids = array_filter(
@@ -239,14 +239,14 @@ abstract class IdList implements \IteratorAggregate, \Countable
 
     // -- Accessors
 
-    /** @psalm-param T $id */
+    /** @param T $id */
     public function containsId(Id $id): bool
     {
         // The strict value is used explicitly to convey the importance of not validating strictly. It has to use a string cast.
         return in_array($id, $this->ids, false);
     }
 
-    /** @psalm-param T $id */
+    /** @param T $id */
     public function notContainsId(Id $id): bool
     {
         return !$this->containsId($id);
@@ -297,7 +297,7 @@ abstract class IdList implements \IteratorAggregate, \Countable
         return true;
     }
 
-    /** @psalm-return T */
+    /** @return T */
     public function idAtPosition(int $position): Id
     {
         return $this->ids[$position];
@@ -317,7 +317,7 @@ abstract class IdList implements \IteratorAggregate, \Countable
     // -- Guards
 
     /**
-     * @psalm-param T $id
+     * @param T $id
      *
      * @throws IdListDoesNotContainId
      */
@@ -329,7 +329,7 @@ abstract class IdList implements \IteratorAggregate, \Countable
     }
 
     /**
-     * @psalm-param T $id
+     * @param T $id
      *
      * @throws IdListDoesContainId
      */
@@ -341,7 +341,7 @@ abstract class IdList implements \IteratorAggregate, \Countable
     }
 
     /**
-     * @psalm-param T $id
+     * @param T $id
      *
      * @throws IdListIsNotEmpty
      */

--- a/src/ValueObject/IdList.php
+++ b/src/ValueObject/IdList.php
@@ -113,7 +113,7 @@ abstract class IdList implements \IteratorAggregate, \Countable
     public function addIdWhenNotInList(Id $id): static
     {
         if ($this->containsId($id)) {
-            return new static($this->ids);
+            return $this;
         }
 
         $ids = $this->ids;

--- a/tests/Serializer/IdListNormalizerTest.php
+++ b/tests/Serializer/IdListNormalizerTest.php
@@ -14,6 +14,7 @@ final class IdListNormalizerTest extends TestCase
 {
     /**
      * @test
+     *
      * @covers ::normalize
      * @covers ::denormalize
      * @covers ::isValid
@@ -40,6 +41,7 @@ final class IdListNormalizerTest extends TestCase
 
     /**
      * @test
+     *
      * @covers ::denormalize
      */
     public function id_list_denormalization_with_null_works(): void
@@ -56,6 +58,7 @@ final class IdListNormalizerTest extends TestCase
 
     /**
      * @test
+     *
      * @covers ::denormalize
      * @covers ::isValid
      */
@@ -79,6 +82,7 @@ final class IdListNormalizerTest extends TestCase
 
     /**
      * @test
+     *
      * @covers ::supportsNormalization
      */
     public function supports_normalization(): void
@@ -94,6 +98,7 @@ final class IdListNormalizerTest extends TestCase
 
     /**
      * @test
+     *
      * @covers ::supportsDenormalization
      */
     public function supports_denormalization(): void

--- a/tests/Serializer/IdNormalizerTest.php
+++ b/tests/Serializer/IdNormalizerTest.php
@@ -12,6 +12,7 @@ final class IdNormalizerTest extends TestCase
 {
     /**
      * @test
+     *
      * @covers ::normalize
      * @covers ::denormalize
      */
@@ -32,6 +33,7 @@ final class IdNormalizerTest extends TestCase
 
     /**
      * @test
+     *
      * @covers ::denormalize
      */
     public function id_denormalization_with_null_works(): void
@@ -48,6 +50,7 @@ final class IdNormalizerTest extends TestCase
 
     /**
      * @test
+     *
      * @covers ::supportsNormalization
      */
     public function supports_normalization(): void
@@ -63,6 +66,7 @@ final class IdNormalizerTest extends TestCase
 
     /**
      * @test
+     *
      * @covers ::supportsDenormalization
      */
     public function supports_denormalization(): void

--- a/tests/ValueObject/IdListTest.php
+++ b/tests/ValueObject/IdListTest.php
@@ -25,7 +25,9 @@ final class IdListTest extends TestCase
 
     /**
      * @test
+     *
      * @covers ::__construct
+     *
      * @doesNotPerformAssertions
      */
     public function id_list_construction_works(): void
@@ -40,8 +42,10 @@ final class IdListTest extends TestCase
 
     /**
      * @test
+     *
      * @covers ::__construct
      * @covers ::mustOnlyContainIdsOfHandledClass
+     *
      * @doesNotPerformAssertions
      */
     public function id_list_construction_works_with_ids_of_subclass(): void
@@ -57,6 +61,7 @@ final class IdListTest extends TestCase
 
     /**
      * @test
+     *
      * @covers ::__construct
      * @covers ::mustNotContainDuplicateIds
      */
@@ -79,6 +84,7 @@ final class IdListTest extends TestCase
 
     /**
      * @test
+     *
      * @covers ::__construct
      * @covers ::mustOnlyContainIdsOfHandledClass
      */
@@ -99,7 +105,9 @@ final class IdListTest extends TestCase
 
     /**
      * @test
+     *
      * @covers ::fromIds
+     *
      * @doesNotPerformAssertions
      */
     public function id_list_construction_from_ids_works(): void
@@ -114,6 +122,7 @@ final class IdListTest extends TestCase
 
     /**
      * @test
+     *
      * @covers ::emptyList
      */
     public function empty_list_works(): void
@@ -129,6 +138,7 @@ final class IdListTest extends TestCase
 
     /**
      * @test
+     *
      * @covers ::fromIdLists
      */
     public function from_id_lists_works(): void
@@ -158,6 +168,7 @@ final class IdListTest extends TestCase
 
     /**
      * @test
+     *
      * @covers ::fromIdLists
      */
     public function from_id_lists_with_duplicates_works(): void
@@ -189,6 +200,7 @@ final class IdListTest extends TestCase
 
     /**
      * @test
+     *
      * @covers ::addId
      */
     public function add_id_works(): void
@@ -213,6 +225,7 @@ final class IdListTest extends TestCase
 
     /**
      * @test
+     *
      * @covers ::addId
      */
     public function add_id_fails_with_duplicate_id(): void
@@ -233,6 +246,7 @@ final class IdListTest extends TestCase
 
     /**
      * @test
+     *
      * @covers ::addIdWhenNotInList
      */
     public function add_id_when_not_in_list_works(): void
@@ -264,6 +278,7 @@ final class IdListTest extends TestCase
 
     /**
      * @test
+     *
      * @covers ::removeId
      */
     public function remove_id_works(): void
@@ -291,6 +306,7 @@ final class IdListTest extends TestCase
 
     /**
      * @test
+     *
      * @covers ::diff
      */
     public function id_list_diff_works(): void
@@ -330,6 +346,7 @@ final class IdListTest extends TestCase
 
     /**
      * @test
+     *
      * @covers ::diff
      */
     public function id_list_diff_works_with_empty_list(): void
@@ -362,6 +379,7 @@ final class IdListTest extends TestCase
 
     /**
      * @test
+     *
      * @covers ::intersect
      */
     public function id_list_intersect_works(): void
@@ -398,8 +416,10 @@ final class IdListTest extends TestCase
 
     /**
      * @test
+     *
      * @covers ::mustContainId
      * @covers ::mustNotContainId
+     *
      * @doesNotPerformAssertions
      */
     public function id_list_must_and_must_not_contains_works(): void
@@ -429,6 +449,7 @@ final class IdListTest extends TestCase
 
     /**
      * @test
+     *
      * @covers ::mustContainId
      */
     public function id_list_must_contain_throws_exception(): void
@@ -452,6 +473,7 @@ final class IdListTest extends TestCase
 
     /**
      * @test
+     *
      * @covers ::mustNotContainId
      */
     public function id_list_must_not_contain_throws_exception(): void
@@ -476,7 +498,9 @@ final class IdListTest extends TestCase
 
     /**
      * @test
+     *
      * @covers ::mustBeEmpty
+     *
      * @doesNotPerformAssertions
      */
     public function id_list_must_be_empty_works(): void
@@ -490,6 +514,7 @@ final class IdListTest extends TestCase
 
     /**
      * @test
+     *
      * @covers ::mustBeEmpty
      */
     public function id_list_must_be_empty_throws_exception_when_not_empty(): void
@@ -510,6 +535,7 @@ final class IdListTest extends TestCase
 
     /**
      * @test
+     *
      * @covers ::isEmpty
      * @covers ::isNotEmpty
      */
@@ -533,6 +559,7 @@ final class IdListTest extends TestCase
 
     /**
      * @test
+     *
      * @covers ::map
      */
     public function id_list_map_works(): void
@@ -571,6 +598,7 @@ final class IdListTest extends TestCase
 
     /**
      * @test
+     *
      * @covers ::filter
      */
     public function id_list_filter_works(): void
@@ -611,6 +639,7 @@ final class IdListTest extends TestCase
 
     /**
      * @test
+     *
      * @covers ::every
      */
     public function id_list_every_works(): void
@@ -658,6 +687,7 @@ final class IdListTest extends TestCase
 
     /**
      * @test
+     *
      * @covers ::some
      */
     public function id_list_some_works(): void
@@ -706,6 +736,7 @@ final class IdListTest extends TestCase
 
     /**
      * @test
+     *
      * @covers ::reduce
      */
     public function id_list_reduce_works(): void
@@ -744,6 +775,7 @@ final class IdListTest extends TestCase
 
     /**
      * @test
+     *
      * @covers ::containsId
      * @covers ::notContainsId
      */
@@ -779,6 +811,7 @@ final class IdListTest extends TestCase
 
     /**
      * @test
+     *
      * @covers ::isEqualTo
      * @covers ::isNotEqualTo
      */
@@ -829,6 +862,7 @@ final class IdListTest extends TestCase
 
     /**
      * @test
+     *
      * @covers ::isEqualTo
      * @covers ::isNotEqualTo
      */
@@ -852,6 +886,7 @@ final class IdListTest extends TestCase
 
     /**
      * @test
+     *
      * @covers ::isEqualTo
      * @covers ::isNotEqualTo
      */
@@ -875,6 +910,7 @@ final class IdListTest extends TestCase
 
     /**
      * @test
+     *
      * @covers ::mustBeEqualTo
      */
     public function must_not_be_equal_to(): void
@@ -908,6 +944,7 @@ final class IdListTest extends TestCase
 
     /**
      * @test
+     *
      * @covers ::count
      */
     public function id_list_count_works(): void
@@ -927,6 +964,7 @@ final class IdListTest extends TestCase
 
     /**
      * @test
+     *
      * @covers ::getIterator
      */
     public function id_list_iteration_works(): void
@@ -974,6 +1012,7 @@ final class IdListTest extends TestCase
 
     /**
      * @test
+     *
      * @covers ::getIterator
      */
     public function id_list_works_with_gaps_in_input_list(): void
@@ -1008,6 +1047,7 @@ final class IdListTest extends TestCase
 
     /**
      * @test
+     *
      * @covers ::isInSameOrder
      * @covers ::idAtPosition
      * @covers ::intersect
@@ -1048,6 +1088,7 @@ final class IdListTest extends TestCase
 
     /**
      * @test
+     *
      * @covers ::idsAsStringList
      */
     public function id_list_as_string_works(): void

--- a/tests/ValueObject/IdTest.php
+++ b/tests/ValueObject/IdTest.php
@@ -15,8 +15,10 @@ final class IdTest extends TestCase
 {
     /**
      * @test
+     *
      * @covers ::__construct
      * @covers ::fromString
+     *
      * @doesNotPerformAssertions
      */
     public function construction_works(): void
@@ -29,6 +31,7 @@ final class IdTest extends TestCase
 
     /**
      * @test
+     *
      * @covers ::__construct
      */
     public function construction_with_invalid_id_fails(): void
@@ -42,6 +45,7 @@ final class IdTest extends TestCase
 
     /**
      * @test
+     *
      * @covers ::isEqualTo
      */
     public function user_id_is_equal(): void
@@ -56,6 +60,7 @@ final class IdTest extends TestCase
 
     /**
      * @test
+     *
      * @covers ::isNotEqualTo
      */
     public function user_id_is_not_equal(): void
@@ -70,7 +75,9 @@ final class IdTest extends TestCase
 
     /**
      * @test
+     *
      * @covers ::mustBeEqualTo
+     *
      * @doesNotPerformAssertions
      */
     public function user_id_must_be_equal(): void
@@ -85,7 +92,9 @@ final class IdTest extends TestCase
 
     /**
      * @test
+     *
      * @covers ::mustNotBeEqualTo
+     *
      * @doesNotPerformAssertions
      */
     public function user_id_must_not_be_equal(): void
@@ -100,6 +109,7 @@ final class IdTest extends TestCase
 
     /**
      * @test
+     *
      * @covers ::mustBeEqualTo
      */
     public function user_id_must_be_equal_fails(): void
@@ -117,6 +127,7 @@ final class IdTest extends TestCase
 
     /**
      * @test
+     *
      * @covers ::mustNotBeEqualTo
      */
     public function user_id_must_not_be_equal_fails(): void


### PR DESCRIPTION
## Changes

- Return same instance of list when `addIdWhenNotInList` doesn't mutate the list.