### PR TITLE
Add PHPStan to system and fix issues

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 0.5.0
 
 - Reduced visibility of internal methods `idAtPosition`, `mustNotContainDuplicateIds` and `mustOnlyContainIdsOfHandledClass` of `IdList` from `public` to `private`.
+- Added PHPStan on level 9 and fixed PHPStan issues.
 
 ## 0.4.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,12 @@
 # Changelog
 
+## 0.5.1
+
+- Added PHPStan on level 9 and fixed PHPStan issues.
+
 ## 0.5.0
 
 - Reduced visibility of internal methods `idAtPosition`, `mustNotContainDuplicateIds` and `mustOnlyContainIdsOfHandledClass` of `IdList` from `public` to `private`.
-- Added PHPStan on level 9 and fixed PHPStan issues.
 
 ## 0.4.0
 

--- a/Makefile
+++ b/Makefile
@@ -118,6 +118,7 @@ php-8.2-tests-html-coverage:
 php-code-validation:
 	docker-compose run --rm php-8.1 ./vendor/bin/php-cs-fixer fix
 	docker-compose run --rm php-8.1 ./vendor/bin/psalm --show-info=false --no-diff
+	docker-compose run --rm php-8.1 ./vendor/bin/phpstan --xdebug
 
 ## php-mutation-testing		Run mutation testing with default PHP version (8.1).
 .PHONY: php-mutation-testing

--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,8 @@
     "vimeo/psalm": "^4.12",
     "friendsofphp/php-cs-fixer": "^3.3",
     "phpunit/phpunit": "^9.5",
-    "infection/infection": "^0.26.15"
+    "infection/infection": "^0.26.15",
+    "phpstan/phpstan": "^1.9"
   },
   "suggest": {
     "ext-uuid": "Improves performance of id creation and validation. symfony/polyfill-uuid is used as a fallback."

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "b7da965d21c2788ab8cd3ff0c2ab1929",
+    "content-hash": "556a3c78c9de41f261741e30de52687c",
     "packages": [
         {
             "name": "doctrine/cache",
@@ -4273,6 +4273,65 @@
             "time": "2022-10-14T12:47:21+00:00"
         },
         {
+            "name": "phpstan/phpstan",
+            "version": "1.9.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phpstan/phpstan.git",
+                "reference": "d6fdf01c53978b6429f1393ba4afeca39cc68afa"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/d6fdf01c53978b6429f1393ba4afeca39cc68afa",
+                "reference": "d6fdf01c53978b6429f1393ba4afeca39cc68afa",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.2|^8.0"
+            },
+            "conflict": {
+                "phpstan/phpstan-shim": "*"
+            },
+            "bin": [
+                "phpstan",
+                "phpstan.phar"
+            ],
+            "type": "library",
+            "autoload": {
+                "files": [
+                    "bootstrap.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "PHPStan - PHP Static Analysis Tool",
+            "keywords": [
+                "dev",
+                "static analysis"
+            ],
+            "support": {
+                "issues": "https://github.com/phpstan/phpstan/issues",
+                "source": "https://github.com/phpstan/phpstan/tree/1.9.2"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/ondrejmirtes",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/phpstan",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/phpstan/phpstan",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2022-11-10T09:56:11+00:00"
+        },
+        {
             "name": "phpunit/php-code-coverage",
             "version": "9.2.17",
             "source": {
@@ -6668,16 +6727,16 @@
         },
         {
             "name": "vimeo/psalm",
-            "version": "4.29.0",
+            "version": "4.30.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/vimeo/psalm.git",
-                "reference": "7ec5ffbd5f68ae03782d7fd33fff0c45a69f95b3"
+                "reference": "d0bc6e25d89f649e4f36a534f330f8bb4643dd69"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/vimeo/psalm/zipball/7ec5ffbd5f68ae03782d7fd33fff0c45a69f95b3",
-                "reference": "7ec5ffbd5f68ae03782d7fd33fff0c45a69f95b3",
+                "url": "https://api.github.com/repos/vimeo/psalm/zipball/d0bc6e25d89f649e4f36a534f330f8bb4643dd69",
+                "reference": "d0bc6e25d89f649e4f36a534f330f8bb4643dd69",
                 "shasum": ""
             },
             "require": {
@@ -6770,9 +6829,9 @@
             ],
             "support": {
                 "issues": "https://github.com/vimeo/psalm/issues",
-                "source": "https://github.com/vimeo/psalm/tree/4.29.0"
+                "source": "https://github.com/vimeo/psalm/tree/4.30.0"
             },
-            "time": "2022-10-11T17:09:17+00:00"
+            "time": "2022-11-06T20:37:08+00:00"
         },
         {
             "name": "webmozart/assert",

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,0 +1,9 @@
+parameters:
+  level: 9
+  paths:
+    - src
+    - tests
+  checkGenericClassInNonGenericObjectType: false
+  excludePaths:
+    # The @template annotations are clashing with the ones of Psalm
+    - src/ValueObject/IdList.php

--- a/src/DependencyInjection/IdsExtension.php
+++ b/src/DependencyInjection/IdsExtension.php
@@ -12,7 +12,8 @@ use Symfony\Component\DependencyInjection\Loader\YamlFileLoader;
 /** @codeCoverageIgnore */
 final class IdsExtension extends Extension
 {
-    public function load(array $configs, ContainerBuilder $container)
+    /** @param array<mixed> $configs */
+    public function load(array $configs, ContainerBuilder $container): void
     {
         $loader = new YamlFileLoader($container, new FileLocator(__DIR__.'/../Resources/config'));
         $loader->load('services.yaml');

--- a/src/Serializer/IdListNormalizer.php
+++ b/src/Serializer/IdListNormalizer.php
@@ -13,28 +13,40 @@ use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
 
 final class IdListNormalizer implements NormalizerInterface, DenormalizerInterface, CacheableSupportsMethodInterface
 {
-    /** @param IdList|object $data */
+    /**
+     * @param IdList|object                     $data
+     * @param array<string, string|int|boolean> $context
+     */
     public function supportsNormalization($data, $format = null, array $context = []): bool
     {
         return $data instanceof IdList;
     }
 
-    /** @param class-string $type */
+    /**
+     * @param class-string                      $type
+     * @param array<string, string|int|boolean> $context
+     */
     public function supportsDenormalization($data, $type, $format = null, array $context = []): bool
     {
         return class_exists($type)
             && get_parent_class($type) === IdList::class;
     }
 
-    /** @param IdList $object */
+    /**
+     * @param IdList                            $object
+     * @param array<string, string|int|boolean> $context
+     *
+     * @return array<int, string>
+     */
     public function normalize($object, $format = null, array $context = []): array
     {
         return $object->idsAsStringList();
     }
 
     /**
-     * @param ?array<int, string>  $data
-     * @param class-string<IdList> $type
+     * @param ?array<int, string>               $data
+     * @param class-string<IdList>              $type
+     * @param array<string, string|int|boolean> $context
      */
     public function denormalize($data, $type, $format = null, array $context = []): ?IdList
     {

--- a/src/Serializer/IdNormalizer.php
+++ b/src/Serializer/IdNormalizer.php
@@ -11,27 +11,34 @@ use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
 
 final class IdNormalizer implements NormalizerInterface, DenormalizerInterface, CacheableSupportsMethodInterface
 {
+    /** @param array<string, string|int|boolean> $context */
     public function supportsNormalization($data, $format = null, array $context = []): bool
     {
         return $data instanceof Id;
     }
 
-    /** @param class-string $type */
+    /**
+     * @param class-string                      $type
+     * @param array<string, string|int|boolean> $context
+     */
     public function supportsDenormalization($data, $type, $format = null, array $context = []): bool
     {
         return is_subclass_of($type, Id::class);
     }
 
-    /** @param Id $object */
+    /**
+     * @param Id                                $object
+     * @param array<string, string|int|boolean> $context
+     */
     public function normalize($object, $format = null, array $context = []): string
     {
         return (string) $object;
     }
 
     /**
-     * @param ?string $data
-     *
-     * @psalm-param class-string<Id> $type
+     * @param ?string                           $data
+     * @param class-string<Id>                  $type
+     * @param array<string, string|int|boolean> $context
      */
     public function denormalize($data, $type, $format = null, array $context = []): ?Id
     {
@@ -39,7 +46,6 @@ final class IdNormalizer implements NormalizerInterface, DenormalizerInterface, 
             return null;
         }
 
-        /** @noinspection PhpUndefinedMethodInspection */
         return $type::fromString($data);
     }
 

--- a/src/ValueObject/IdList.php
+++ b/src/ValueObject/IdList.php
@@ -83,6 +83,8 @@ abstract class IdList implements \IteratorAggregate, \Countable
      * @template TT of T
      *
      * @return class-string<TT>
+     *
+     * @phpstan-return class-string<T>
      */
     abstract public static function handlesIdClass(): string;
 

--- a/tests/Serializer/IdListNormalizerTest.php
+++ b/tests/Serializer/IdListNormalizerTest.php
@@ -76,7 +76,11 @@ final class IdListNormalizerTest extends TestCase
         ];
 
         // -- Act
-        /** @psalm-suppress InvalidScalarArgument */
+        /**
+         * @psalm-suppress InvalidScalarArgument
+         *
+         * @phpstan-ignore-next-line
+         */
         $normalizer->denormalize($invalidData, UserIdList::class);
     }
 

--- a/tests/ValueObject/IdListTest.php
+++ b/tests/ValueObject/IdListTest.php
@@ -115,7 +115,11 @@ final class IdListTest extends TestCase
         $this->expectException(IdClassNotHandledInList::class);
 
         // -- Arrange & Act
-        /** @psalm-suppress InvalidArgument */
+        /**
+         * @psalm-suppress InvalidArgument
+         *
+         * @phpstan-ignore-next-line
+         */
         new UserIdList([
             UserId::generateRandom(),
             UserId::generateRandom(),


### PR DESCRIPTION
## Changes

- Add PHPStan with level 9 to package and fix nearly all issues.

PHPStan also tries to read the Psalm annotations and both aren't able to read all `@template` annotations. Therefore, the `IdList.php` is excluded from PHPStan for now. This will be improved as soon as Psalm or PHPStan are getting better understanding of it. I've extended the discussion with an example on the Psalm Github Issue: https://github.com/vimeo/psalm/issues/2571#issuecomment-1321743888

Resolves #29 