### PR TITLE
Change IdList diff behavior

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,8 +3,15 @@
 ## 0.7.0
 
 - Changed the way `IdList`'s `diff` method behaves to match `array_diff`'s behavior.
-  - Previously it returned an `IdList` containing all elements that were present in the `IdList` itself but not in the given `IdList` (method parameter) aswell as all elements that were in the given `IdList` (method parameter) but not in the `IdList` itself.
+  - Previously it returned an `IdList` containing all elements that were present in the `IdList` itself but not in the given `IdList` (method parameter) as well as all elements that were in the given `IdList` (method parameter) but not in the `IdList` itself.
   - Now it returns an `IdList` containing only the elements that are present in the `IdList` itself but not in the given `IdList` (method parameter).
+
+## 0.6.0
+
+- Added `containsEveryId(self $idList): bool` to `IdList`.
+- Added `containsSomeIds(self $idList): bool` to `IdList`.
+- Added `mustContainEveryId(self $idList): void` to `IdList`.
+- Added `mustContainSomeIds(self $idList): void` to `IdList`.
 
 ## 0.5.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,9 @@
 
 ## 0.7.0
 
-- Changed the way `IdList`'s `diff` method behaves to match `array_diff`'s behavior. Previously it returned an `IdList` containing all elements that were present in the `IdList` itself but not in the given `IdList` (method parameter) aswell as all elements that were in the given `IdList` (method parameter) but not in the `IdList` itself. Now it returns an `IdList` containing only the elements that are present in the `IdList` itself but not in the given `IdList` (method parameter).
+- Changed the way `IdList`'s `diff` method behaves to match `array_diff`'s behavior.
+  - Previously it returned an `IdList` containing all elements that were present in the `IdList` itself but not in the given `IdList` (method parameter) aswell as all elements that were in the given `IdList` (method parameter) but not in the `IdList` itself.
+  - Now it returns an `IdList` containing only the elements that are present in the `IdList` itself but not in the given `IdList` (method parameter).
 
 ## 0.5.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.7.0
+
+- Changed the way `IdList`'s `diff` method behaves to match `array_diff`'s behavior. Previously it returned an `IdList` containing all elements that were present in the `IdList` itself but not in the given `IdList` (method parameter) aswell as all elements that were in the given `IdList` (method parameter) but not in the `IdList` itself. Now it returns an `IdList` containing only the elements that are present in the `IdList` itself but not in the given `IdList` (method parameter).
+
 ## 0.5.1
 
 - Added PHPStan on level 9 and fixed PHPStan issues.

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ composer require digital-craftsman/ids
 
 It's recommended that you install the [`uuid` PHP extension](https://pecl.php.net/package/uuid) for better performance of id creation and validation.  `symfony/polyfill-uuid` is used as a fallback. You can [prevent installing the polyfill](./docs/prevent-polyfill-usage.md) when you've installed the PHP extension.
 
-> ⚠️ This bundle can be used (and is being used) in production, but hasn't reached version 1.0 yet. Therefore, there will be breaking changes between minor versions. I'd recommend that you require the bundle only with the current minor version like `composer require digital-craftsman/ids:0.6.*`. Breaking changes are described in the releases and [the changelog](./CHANGELOG.md). Updates are described in the [upgrade guide](./UPGRADE.md).
+> ⚠️ This bundle can be used (and is being used) in production, but hasn't reached version 1.0 yet. Therefore, there will be breaking changes between minor versions. I'd recommend that you require the bundle only with the current minor version like `composer require digital-craftsman/ids:0.7.*`. Breaking changes are described in the releases and [the changelog](./CHANGELOG.md). Updates are described in the [upgrade guide](./UPGRADE.md).
 
 ## Working with ids
 

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -1,5 +1,11 @@
 # Upgrade guide
 
+## From 0.5.0 to 0.7.0
+
+The `diff` method of `IdList` now behaves like `array_diff`.
+
+Consider implementing the previous behavior in your codebase if you have used `diff`.
+
 ## From 0.4.* to 0.5.0
 
 ### Reduced visibility

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -1,6 +1,6 @@
 # Upgrade guide
 
-## From 0.5.0 to 0.7.0
+## From 0.6.* to 0.7.0
 
 The `diff` method of `IdList` now behaves like `array_diff`.
 

--- a/src/ValueObject/IdList.php
+++ b/src/ValueObject/IdList.php
@@ -132,17 +132,7 @@ abstract class IdList implements \IteratorAggregate, \Countable
     /** @param static $idList */
     public function diff(self $idList): static
     {
-        $idsNotInList = [];
-        foreach ($this->ids as $id) {
-            if ($idList->notContainsId($id)) {
-                $idsNotInList[] = $id;
-            }
-        }
-        foreach ($idList as $id) {
-            if ($this->notContainsId($id)) {
-                $idsNotInList[] = $id;
-            }
-        }
+        $idsNotInList = array_diff($this->ids, $idList->ids);
 
         return new static($idsNotInList);
     }

--- a/tests/ValueObject/IdListTest.php
+++ b/tests/ValueObject/IdListTest.php
@@ -362,13 +362,10 @@ final class IdListTest extends TestCase
 
         // -- Assert
         self::assertCount(2, $diffListFromOriginalList);
-        self::assertCount(2, $diffListFromPartialList);
+        self::assertCount(0, $diffListFromPartialList);
 
         self::assertTrue($diffListFromOriginalList->containsId($idMarkus));
         self::assertTrue($diffListFromOriginalList->containsId($idTom));
-
-        self::assertTrue($diffListFromPartialList->containsId($idMarkus));
-        self::assertTrue($diffListFromPartialList->containsId($idTom));
     }
 
     /**
@@ -399,7 +396,7 @@ final class IdListTest extends TestCase
 
         // -- Assert
         self::assertCount(4, $diffListFromOriginal);
-        self::assertCount(4, $diffListFromEmpty);
+        self::assertCount(0, $diffListFromEmpty);
     }
 
     // -- Intersect


### PR DESCRIPTION
## Changes

- Changed the way `IdList`'s `diff` method behaves to match `array_diff`'s behavior.
  - Previously it returned an `IdList` containing all elements that were present in the `IdList` itself but not in the given `IdList` (method parameter) aswell as all elements that were in the given `IdList` (method parameter) but not in the `IdList` itself.
  - Now it returns an `IdList` containing only the elements that are present in the `IdList` itself but not in the given `IdList` (method parameter).