### PR TITLE
Add performance improvements for large id lists

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 0.8.0
 
 - **[Breaking change](./UPGRADE.md#updated-behaviour-of-idlistremoveid)**: Updated method `removeId` from `IdList` to throw an exception when the id is not in the list. This is the same behaviour as the `addId` method has.
+- **[Breaking change](./UPGRADE.md#internal-ids-of-idlist-now-use-the-string-representation-of-an-id-as-key-instead-of-the-index)**: Performance improvements for larger lists. Internal ids of `IdList` now use the string representation of an id as key instead of the index.
 - Added new method `removeIdWhenInList(Id $id): static` to `IdList`.
 - Added new method `addIds(self $idList): static` to `IdList`.
 - Added new method `addIdsWhenNotInList(self $idList): static` to `IdList`.

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -6,6 +6,12 @@
 
 The `removeId` method of `IdList` now behaves like the `addId` method in that it throws an exception (`IdListDoesNotContainId`) when the id that has to be removed, doesn't exist in the list. Use the new `removeIdWhenInList` method if you want to remove an id without caring whether it's in the list or not.
 
+### Internal ids of `IdList` now use the string representation of an id as key instead of the index
+
+This greatly improves performance of large lists. If you still need them with an index, or ordered, you can use the new `OrderedIdList` for your id list classes. Those lists won't benefit from the performance improvement though.
+
+The method `isInSameOrder` was removed from `IdList` but is still available on the `OrderedIdList`.
+
 ## From 0.6.* to 0.7.0
 
 ### Updated behaviour of `IdList::diff`

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -7,3 +7,4 @@ parameters:
   excludePaths:
     # The @template annotations are clashing with the ones of Psalm
     - src/ValueObject/IdList.php
+    - src/ValueObject/OrderedIdList.php

--- a/src/Doctrine/IdListType.php
+++ b/src/Doctrine/IdListType.php
@@ -55,7 +55,7 @@ abstract class IdListType extends Type
         }
 
         /** @noinspection PhpUndefinedMethodInspection */
-        return $idListClass::fromIds($ids);
+        return new $idListClass($ids);
     }
 
     /** @codeCoverageIgnore */

--- a/src/Doctrine/IdListType.php
+++ b/src/Doctrine/IdListType.php
@@ -6,6 +6,7 @@ namespace DigitalCraftsman\Ids\Doctrine;
 
 use DigitalCraftsman\Ids\ValueObject\Id;
 use DigitalCraftsman\Ids\ValueObject\IdList;
+use DigitalCraftsman\Ids\ValueObject\OrderedIdList;
 use Doctrine\DBAL\Platforms\AbstractPlatform;
 use Doctrine\DBAL\Types\Type;
 
@@ -13,7 +14,7 @@ abstract class IdListType extends Type
 {
     abstract protected function getTypeName(): string;
 
-    /** @psalm-return class-string<IdList> */
+    /** @psalm-return class-string<IdList|OrderedIdList> */
     abstract protected function getIdListClass(): string;
 
     /** @psalm-return class-string<Id> */
@@ -25,7 +26,7 @@ abstract class IdListType extends Type
         return $platform->getJsonTypeDeclarationSQL($column);
     }
 
-    /** @param ?IdList $value */
+    /** @param IdList|OrderedIdList|null $value */
     public function convertToDatabaseValue($value, AbstractPlatform $platform): ?string
     {
         if ($value === null) {

--- a/src/Serializer/IdListNormalizer.php
+++ b/src/Serializer/IdListNormalizer.php
@@ -28,13 +28,14 @@ final class IdListNormalizer implements NormalizerInterface, DenormalizerInterfa
      */
     public function supportsDenormalization($data, $type, $format = null, array $context = []): bool
     {
+        if (!class_exists($type)) {
+            return false;
+        }
+
         $parentClass = get_parent_class($type);
 
-        return class_exists($type)
-            && (
-                $parentClass === IdList::class
-                || $parentClass === OrderedIdList::class
-            );
+        return $parentClass === IdList::class
+            || $parentClass === OrderedIdList::class;
     }
 
     /**

--- a/src/Serializer/IdListNormalizer.php
+++ b/src/Serializer/IdListNormalizer.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace DigitalCraftsman\Ids\Serializer;
 
 use DigitalCraftsman\Ids\ValueObject\IdList;
+use DigitalCraftsman\Ids\ValueObject\OrderedIdList;
 use Symfony\Component\Serializer\Normalizer\CacheableSupportsMethodInterface;
 use Symfony\Component\Serializer\Normalizer\DenormalizerInterface;
 use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
@@ -12,12 +13,13 @@ use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
 final class IdListNormalizer implements NormalizerInterface, DenormalizerInterface, CacheableSupportsMethodInterface
 {
     /**
-     * @param IdList|object                     $data
+     * @param IdList|OrderedIdList|object       $data
      * @param array<string, string|int|boolean> $context
      */
     public function supportsNormalization($data, $format = null, array $context = []): bool
     {
-        return $data instanceof IdList;
+        return $data instanceof IdList
+            || $data instanceof OrderedIdList;
     }
 
     /**
@@ -26,12 +28,17 @@ final class IdListNormalizer implements NormalizerInterface, DenormalizerInterfa
      */
     public function supportsDenormalization($data, $type, $format = null, array $context = []): bool
     {
+        $parentClass = get_parent_class($type);
+
         return class_exists($type)
-            && get_parent_class($type) === IdList::class;
+            && (
+                $parentClass === IdList::class
+                || $parentClass === OrderedIdList::class
+            );
     }
 
     /**
-     * @param IdList                            $object
+     * @param IdList|OrderedIdList              $object
      * @param array<string, string|int|boolean> $context
      *
      * @return array<int, string>
@@ -42,11 +49,11 @@ final class IdListNormalizer implements NormalizerInterface, DenormalizerInterfa
     }
 
     /**
-     * @param ?array<int, string>               $data
-     * @param class-string<IdList>              $type
-     * @param array<string, string|int|boolean> $context
+     * @param ?array<int, string>                $data
+     * @param class-string<IdList|OrderedIdList> $type
+     * @param array<string, string|int|boolean>  $context
      */
-    public function denormalize($data, $type, $format = null, array $context = []): ?IdList
+    public function denormalize($data, $type, $format = null, array $context = []): IdList|OrderedIdList|null
     {
         if ($data === null) {
             return null;

--- a/src/Serializer/IdListNormalizer.php
+++ b/src/Serializer/IdListNormalizer.php
@@ -23,7 +23,7 @@ final class IdListNormalizer implements NormalizerInterface, DenormalizerInterfa
     }
 
     /**
-     * @param class-string                      $type
+     * @param string                            $type
      * @param array<string, string|int|boolean> $context
      */
     public function supportsDenormalization($data, $type, $format = null, array $context = []): bool

--- a/src/Serializer/IdListNormalizer.php
+++ b/src/Serializer/IdListNormalizer.php
@@ -4,9 +4,7 @@ declare(strict_types=1);
 
 namespace DigitalCraftsman\Ids\Serializer;
 
-use DigitalCraftsman\Ids\ValueObject\Id;
 use DigitalCraftsman\Ids\ValueObject\IdList;
-use Symfony\Component\Serializer\Exception\UnexpectedValueException;
 use Symfony\Component\Serializer\Normalizer\CacheableSupportsMethodInterface;
 use Symfony\Component\Serializer\Normalizer\DenormalizerInterface;
 use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
@@ -54,40 +52,19 @@ final class IdListNormalizer implements NormalizerInterface, DenormalizerInterfa
             return null;
         }
 
-        if (!$this->isValid($data)) {
-            throw new UnexpectedValueException('Expected a valid list.');
-        }
-
         $idClass = $type::handlesIdClass();
 
-        /** @var array<int, Id> $ids */
-        $ids = array_map(
-            static fn (string $id) => new $idClass($id),
-            $data,
-        );
+        $ids = [];
+        foreach ($data as $string) {
+            $ids[] = new $idClass($string);
+        }
 
-        return $type::fromIds($ids);
+        return new $type($ids);
     }
 
     /** @codeCoverageIgnore */
     public function hasCacheableSupportsMethod(): bool
     {
-        return true;
-    }
-
-    /**
-     * Uuid::isValid($string) is not in here on purpose as the Id object itself calls that method on construction.
-     *
-     * @param array<int, string> $data
-     */
-    private function isValid(array $data): bool
-    {
-        foreach ($data as $string) {
-            if (!is_string($string)) {
-                return false;
-            }
-        }
-
         return true;
     }
 }

--- a/src/Serializer/IdNormalizer.php
+++ b/src/Serializer/IdNormalizer.php
@@ -18,7 +18,7 @@ final class IdNormalizer implements NormalizerInterface, DenormalizerInterface, 
     }
 
     /**
-     * @param class-string                      $type
+     * @param string                            $type
      * @param array<string, string|int|boolean> $context
      */
     public function supportsDenormalization($data, $type, $format = null, array $context = []): bool

--- a/src/ValueObject/Id.php
+++ b/src/ValueObject/Id.php
@@ -14,7 +14,7 @@ abstract class Id implements \Stringable
     // Construction
 
     final public function __construct(
-        protected readonly string $value,
+        public readonly string $value,
     ) {
         if (!uuid_is_valid($value)) {
             throw new InvalidId($value);

--- a/src/ValueObject/IdList.php
+++ b/src/ValueObject/IdList.php
@@ -175,7 +175,7 @@ abstract class IdList implements \IteratorAggregate, \Countable
     public function map(callable $mapFunction): array
     {
         /** @psalm-suppress ImpureFunctionCall */
-        return array_map($mapFunction, $this->ids);
+        return array_map($mapFunction, array_values($this->ids));
     }
 
     /** @psalm-param callable(T):bool $filterFunction */
@@ -384,7 +384,7 @@ abstract class IdList implements \IteratorAggregate, \Countable
     /** @return \Iterator<int, T> */
     public function getIterator(): \Iterator
     {
-        return new \ArrayIterator($this->ids);
+        return new \ArrayIterator(array_values($this->ids));
     }
 
     // -- Countable

--- a/src/ValueObject/IdList.php
+++ b/src/ValueObject/IdList.php
@@ -127,7 +127,7 @@ abstract class IdList implements \IteratorAggregate, \Countable
     {
         $existingIds = $this->ids;
         // TODO: Check if the element exists. Wasn't there before
-        unset($existingIds[(string) $id]);
+        unset($existingIds[$id->value]);
 
         return new static($existingIds);
     }
@@ -229,13 +229,13 @@ abstract class IdList implements \IteratorAggregate, \Countable
     /** @param T $id */
     public function containsId(Id $id): bool
     {
-        return array_key_exists((string) $id, $this->ids);
+        return array_key_exists($id->value, $this->ids);
     }
 
     /** @param T $id */
     public function notContainsId(Id $id): bool
     {
-        return !array_key_exists((string) $id, $this->ids);
+        return !array_key_exists($id->value, $this->ids);
     }
 
     public function containsEveryId(self $idList): bool

--- a/src/ValueObject/IdList.php
+++ b/src/ValueObject/IdList.php
@@ -235,7 +235,7 @@ abstract class IdList implements \IteratorAggregate, \Countable
     /** @param T $id */
     public function notContainsId(Id $id): bool
     {
-        return !$this->containsId($id);
+        return !array_key_exists((string) $id, $this->ids);
     }
 
     public function containsEveryId(self $idList): bool

--- a/src/ValueObject/IdList.php
+++ b/src/ValueObject/IdList.php
@@ -131,7 +131,7 @@ abstract class IdList implements \IteratorAggregate, \Countable
 
         $newIds = $this->ids;
         foreach ($idList as $id) {
-            $newIds[] = $id;
+            $newIds[$id->value] = $id;
         }
 
         return new static($newIds);
@@ -145,7 +145,7 @@ abstract class IdList implements \IteratorAggregate, \Countable
         }
 
         $ids = $this->ids;
-        $ids[] = $id;
+        $ids[$id->value] = $id;
 
         return new static($ids);
     }
@@ -156,7 +156,7 @@ abstract class IdList implements \IteratorAggregate, \Countable
         $newIds = $this->ids;
         foreach ($idList as $id) {
             if ($this->notContainsId($id)) {
-                $newIds[] = $id;
+                $newIds[$id->value] = $id;
             }
         }
 
@@ -179,14 +179,12 @@ abstract class IdList implements \IteratorAggregate, \Countable
     {
         $this->mustContainEveryId($idList);
 
-        $ids = [];
-        foreach ($this->ids as $id) {
-            if ($idList->notContainsId($id)) {
-                $ids[] = $id;
-            }
+        $idsWithoutIdsToRemove = $this->ids;
+        foreach ($idList as $id) {
+            unset($idsWithoutIdsToRemove[$id->value]);
         }
 
-        return new static($ids);
+        return new static($idsWithoutIdsToRemove);
     }
 
     /** @param T $id */

--- a/src/ValueObject/IdList.php
+++ b/src/ValueObject/IdList.php
@@ -395,7 +395,7 @@ abstract class IdList implements \IteratorAggregate, \Countable
         return $this->count() > 0;
     }
 
-    /** @return array<int, string> */
+    /** @return list<string> */
     public function idsAsStringList(): array
     {
         return array_keys($this->ids);

--- a/src/ValueObject/OrderedIdList.php
+++ b/src/ValueObject/OrderedIdList.php
@@ -55,6 +55,19 @@ abstract class OrderedIdList implements \IteratorAggregate, \Countable
         return new static($ids);
     }
 
+    /** @param array<int, string> $idStrings */
+    final public static function fromIdStrings(array $idStrings): static
+    {
+        $idClass = static::handlesIdClass();
+
+        $ids = [];
+        foreach ($idStrings as $idString) {
+            $ids[] = new $idClass($idString);
+        }
+
+        return new static($ids);
+    }
+
     final public static function emptyList(): static
     {
         return new static([]);

--- a/tests/Doctrine/IdListTypeTest.php
+++ b/tests/Doctrine/IdListTypeTest.php
@@ -4,7 +4,9 @@ declare(strict_types=1);
 
 namespace DigitalCraftsman\Ids\Doctrine;
 
+use DigitalCraftsman\Ids\Test\Doctrine\OrderedUserIdListType;
 use DigitalCraftsman\Ids\Test\Doctrine\UserIdListType;
+use DigitalCraftsman\Ids\Test\ValueObject\OrderedUserIdList;
 use DigitalCraftsman\Ids\Test\ValueObject\UserId;
 use DigitalCraftsman\Ids\Test\ValueObject\UserIdList;
 use Doctrine\DBAL\Platforms\PostgreSQLPlatform;
@@ -23,6 +25,27 @@ final class IdListTypeTest extends TestCase
             UserId::generateRandom(),
         ]);
         $userIdListType = new UserIdListType();
+        $platform = new PostgreSQLPlatform();
+
+        // -- Act
+        $databaseValue = $userIdListType->convertToDatabaseValue($userIdList, $platform);
+        $phpValue = $userIdListType->convertToPHPValue($databaseValue, $platform);
+
+        // -- Assert
+        self::assertEquals($userIdList, $phpValue);
+    }
+
+    /** @test */
+    public function convert_from_and_to_ordered_id_list_php_value_works(): void
+    {
+        // -- Arrange
+        $userIdList = new OrderedUserIdList([
+            UserId::generateRandom(),
+            UserId::generateRandom(),
+            UserId::generateRandom(),
+            UserId::generateRandom(),
+        ]);
+        $userIdListType = new OrderedUserIdListType();
         $platform = new PostgreSQLPlatform();
 
         // -- Act

--- a/tests/Serializer/IdListNormalizerTest.php
+++ b/tests/Serializer/IdListNormalizerTest.php
@@ -7,7 +7,6 @@ namespace DigitalCraftsman\Ids\Serializer;
 use DigitalCraftsman\Ids\Test\ValueObject\UserId;
 use DigitalCraftsman\Ids\Test\ValueObject\UserIdList;
 use PHPUnit\Framework\TestCase;
-use Symfony\Component\Serializer\Exception\UnexpectedValueException;
 
 /** @coversDefaultClass \DigitalCraftsman\Ids\Serializer\IdListNormalizer */
 final class IdListNormalizerTest extends TestCase
@@ -54,34 +53,6 @@ final class IdListNormalizerTest extends TestCase
 
         // -- Assert
         self::assertNull($denormalizedData);
-    }
-
-    /**
-     * @test
-     *
-     * @covers ::denormalize
-     * @covers ::isValid
-     */
-    public function id_list_denormalization_fails_with_invalid_values(): void
-    {
-        // -- Assert
-        $this->expectException(UnexpectedValueException::class);
-
-        // -- Arrange
-        $normalizer = new IdListNormalizer();
-
-        $invalidData = [
-            (string) UserId::generateRandom(),
-            15,
-        ];
-
-        // -- Act
-        /**
-         * @psalm-suppress InvalidScalarArgument
-         *
-         * @phpstan-ignore-next-line
-         */
-        $normalizer->denormalize($invalidData, UserIdList::class);
     }
 
     /**

--- a/tests/Serializer/IdListNormalizerTest.php
+++ b/tests/Serializer/IdListNormalizerTest.php
@@ -148,7 +148,27 @@ final class IdListNormalizerTest extends TestCase
      *
      * @covers ::supportsDenormalization
      */
-    public function supports_denormalization_fails_with_wrong_type(): void
+    public function supports_denormalization_with_array_of_ids(): void
+    {
+        // -- Arrange
+        $idListData = [
+            (string) UserId::generateRandom(),
+            (string) UserId::generateRandom(),
+            (string) UserId::generateRandom(),
+        ];
+
+        $normalizer = new IdListNormalizer();
+
+        // -- Act & Assert
+        self::assertFalse($normalizer->supportsDenormalization($idListData, sprintf('%s[]', UserId::class)));
+    }
+
+    /**
+     * @test
+     *
+     * @covers ::supportsDenormalization
+     */
+    public function supports_denormalization_with_wrong_type(): void
     {
         // -- Arrange
         $idListData = [

--- a/tests/Serializer/IdListNormalizerTest.php
+++ b/tests/Serializer/IdListNormalizerTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace DigitalCraftsman\Ids\Serializer;
 
+use DigitalCraftsman\Ids\Test\ValueObject\OrderedUserIdList;
 use DigitalCraftsman\Ids\Test\ValueObject\UserId;
 use DigitalCraftsman\Ids\Test\ValueObject\UserIdList;
 use PHPUnit\Framework\TestCase;
@@ -59,10 +60,26 @@ final class IdListNormalizerTest extends TestCase
      *
      * @covers ::supportsNormalization
      */
-    public function supports_normalization(): void
+    public function supports_normalization_for_list(): void
     {
         // -- Arrange
         $userIdList = new UserIdList([]);
+
+        $normalizer = new IdListNormalizer();
+
+        // -- Act & Assert
+        self::assertTrue($normalizer->supportsNormalization($userIdList));
+    }
+
+    /**
+     * @test
+     *
+     * @covers ::supportsNormalization
+     */
+    public function supports_normalization_for_ordered_list(): void
+    {
+        // -- Arrange
+        $userIdList = new OrderedUserIdList([]);
 
         $normalizer = new IdListNormalizer();
 
@@ -91,7 +108,7 @@ final class IdListNormalizerTest extends TestCase
      *
      * @covers ::supportsDenormalization
      */
-    public function supports_denormalization(): void
+    public function supports_denormalization_for_id_list(): void
     {
         // -- Arrange
         $idListData = [
@@ -104,6 +121,26 @@ final class IdListNormalizerTest extends TestCase
 
         // -- Act & Assert
         self::assertTrue($normalizer->supportsDenormalization($idListData, UserIdList::class));
+    }
+
+    /**
+     * @test
+     *
+     * @covers ::supportsDenormalization
+     */
+    public function supports_denormalization_for_ordered_id_list(): void
+    {
+        // -- Arrange
+        $idListData = [
+            (string) UserId::generateRandom(),
+            (string) UserId::generateRandom(),
+            (string) UserId::generateRandom(),
+        ];
+
+        $normalizer = new IdListNormalizer();
+
+        // -- Act & Assert
+        self::assertTrue($normalizer->supportsDenormalization($idListData, OrderedUserIdList::class));
     }
 
     /**

--- a/tests/Serializer/IdListNormalizerTest.php
+++ b/tests/Serializer/IdListNormalizerTest.php
@@ -16,7 +16,6 @@ final class IdListNormalizerTest extends TestCase
      *
      * @covers ::normalize
      * @covers ::denormalize
-     * @covers ::isValid
      */
     public function id_list_normalization_and_denormalization_works(): void
     {

--- a/tests/Test/Doctrine/OrderedUserIdListType.php
+++ b/tests/Test/Doctrine/OrderedUserIdListType.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DigitalCraftsman\Ids\Test\Doctrine;
+
+use DigitalCraftsman\Ids\Doctrine\IdListType;
+use DigitalCraftsman\Ids\Test\ValueObject\OrderedUserIdList;
+use DigitalCraftsman\Ids\Test\ValueObject\UserId;
+
+final class OrderedUserIdListType extends IdListType
+{
+    protected function getTypeName(): string
+    {
+        return 'ordered_user_id_list';
+    }
+
+    protected function getIdListClass(): string
+    {
+        return OrderedUserIdList::class;
+    }
+
+    protected function getIdClass(): string
+    {
+        return UserId::class;
+    }
+}

--- a/tests/Test/ValueObject/OrderedUserIdList.php
+++ b/tests/Test/ValueObject/OrderedUserIdList.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DigitalCraftsman\Ids\Test\ValueObject;
+
+use DigitalCraftsman\Ids\ValueObject\OrderedIdList;
+
+/** @extends OrderedIdList<UserId> */
+final class OrderedUserIdList extends OrderedIdList
+{
+    public static function handlesIdClass(): string
+    {
+        return UserId::class;
+    }
+}

--- a/tests/ValueObject/IdListTest.php
+++ b/tests/ValueObject/IdListTest.php
@@ -45,6 +45,25 @@ final class IdListTest extends TestCase
     /**
      * @test
      *
+     * @covers ::fromIds
+     */
+    public function id_list_from_ids_construction_works(): void
+    {
+        // -- Arrange & Act
+        $ids = [
+            UserId::generateRandom(),
+            UserId::generateRandom(),
+            UserId::generateRandom(),
+        ];
+        $idList = UserIdList::fromIds($ids);
+
+        // -- Assert
+        self::assertCount(3, $idList->ids);
+    }
+
+    /**
+     * @test
+     *
      * @covers ::__construct
      */
     public function id_list_construction_works_with_index_that_is_not_a_list(): void

--- a/tests/ValueObject/IdListTest.php
+++ b/tests/ValueObject/IdListTest.php
@@ -144,9 +144,6 @@ final class IdListTest extends TestCase
 
         // -- Assert
         self::assertCount(3, $userIdList);
-
-        // -- Assert
-        self::assertCount(3, $idList->ids);
     }
 
     /**

--- a/tests/ValueObject/IdListTest.php
+++ b/tests/ValueObject/IdListTest.php
@@ -9,7 +9,6 @@ use DigitalCraftsman\Ids\Test\ValueObject\InstructorId;
 use DigitalCraftsman\Ids\Test\ValueObject\ProjectId;
 use DigitalCraftsman\Ids\Test\ValueObject\UserId;
 use DigitalCraftsman\Ids\Test\ValueObject\UserIdList;
-use DigitalCraftsman\Ids\ValueObject\Exception\DuplicateIds;
 use DigitalCraftsman\Ids\ValueObject\Exception\IdAlreadyInList;
 use DigitalCraftsman\Ids\ValueObject\Exception\IdClassNotHandledInList;
 use DigitalCraftsman\Ids\ValueObject\Exception\IdListDoesContainId;
@@ -58,9 +57,7 @@ final class IdListTest extends TestCase
         ]);
 
         // -- Assert
-        self::assertArrayHasKey(0, $idList->ids);
-        self::assertArrayHasKey(1, $idList->ids);
-        self::assertArrayHasKey(2, $idList->ids);
+        self::assertCount(3, $idList->ids);
     }
 
     /**
@@ -79,29 +76,6 @@ final class IdListTest extends TestCase
             UserId::generateRandom(),
             InstructorId::generateRandom(),
             AdminId::generateRandom(),
-        ]);
-    }
-
-    /**
-     * @test
-     *
-     * @covers ::__construct
-     * @covers ::mustNotContainDuplicateIds
-     */
-    public function id_list_construction_fails_with_duplicates(): void
-    {
-        // -- Assert
-        $this->expectException(DuplicateIds::class);
-
-        // -- Arrange & Act
-        $duplicateId = UserId::generateRandom();
-
-        new UserIdList([
-            $duplicateId,
-            $duplicateId,
-            UserId::generateRandom(),
-            UserId::generateRandom(),
-            UserId::generateRandom(),
         ]);
     }
 

--- a/tests/ValueObject/IdListTest.php
+++ b/tests/ValueObject/IdListTest.php
@@ -45,25 +45,6 @@ final class IdListTest extends TestCase
     /**
      * @test
      *
-     * @covers ::fromIds
-     */
-    public function id_list_from_ids_construction_works(): void
-    {
-        // -- Arrange & Act
-        $ids = [
-            UserId::generateRandom(),
-            UserId::generateRandom(),
-            UserId::generateRandom(),
-        ];
-        $idList = UserIdList::fromIds($ids);
-
-        // -- Assert
-        self::assertCount(3, $idList->ids);
-    }
-
-    /**
-     * @test
-     *
      * @covers ::__construct
      */
     public function id_list_construction_works_with_index_that_is_not_a_list(): void
@@ -127,17 +108,18 @@ final class IdListTest extends TestCase
      * @test
      *
      * @covers ::fromIds
-     *
-     * @doesNotPerformAssertions
      */
     public function id_list_construction_from_ids_works(): void
     {
         // -- Arrange & Act
-        UserIdList::fromIds([
+        $idList = UserIdList::fromIds([
             UserId::generateRandom(),
             UserId::generateRandom(),
             UserId::generateRandom(),
         ]);
+
+        // -- Assert
+        self::assertCount(3, $idList->ids);
     }
 
     /**
@@ -320,6 +302,28 @@ final class IdListTest extends TestCase
         self::assertCount(2, $removedList);
 
         self::assertTrue($removedList->notContainsId($idToRemove));
+    }
+
+    /**
+     * @test
+     *
+     * @covers ::removeId
+     */
+    public function remove_id_fails_when_id_is_not_in_list(): void
+    {
+        // -- Assert
+        $this->expectException(IdListDoesContainId::class);
+
+        // -- Arrange
+        $idToRemove = UserId::generateRandom();
+
+        $idList = new UserIdList([
+            UserId::generateRandom(),
+            UserId::generateRandom(),
+        ]);
+
+        // -- Act
+        $removedList = $idList->removeId($idToRemove);
     }
 
     // -- Diff

--- a/tests/ValueObject/IdListTest.php
+++ b/tests/ValueObject/IdListTest.php
@@ -441,6 +441,8 @@ final class IdListTest extends TestCase
         $idList->removeId($idToRemove);
     }
 
+    // Remove ids
+
     /**
      * @test
      *

--- a/tests/ValueObject/OrderedIdListTest.php
+++ b/tests/ValueObject/OrderedIdListTest.php
@@ -134,17 +134,18 @@ final class OrderedIdListTest extends TestCase
      * @test
      *
      * @covers ::fromIds
-     *
-     * @doesNotPerformAssertions
      */
     public function id_list_construction_from_ids_works(): void
     {
         // -- Arrange & Act
-        OrderedUserIdList::fromIds([
+        $idList = OrderedUserIdList::fromIds([
             UserId::generateRandom(),
             UserId::generateRandom(),
             UserId::generateRandom(),
         ]);
+
+        // -- Assert
+        self::assertCount(3, $idList->ids);
     }
 
     /**

--- a/tests/ValueObject/OrderedIdListTest.php
+++ b/tests/ValueObject/OrderedIdListTest.php
@@ -12,7 +12,9 @@ use DigitalCraftsman\Ids\Test\ValueObject\UserId;
 use DigitalCraftsman\Ids\ValueObject\Exception\DuplicateIds;
 use DigitalCraftsman\Ids\ValueObject\Exception\IdAlreadyInList;
 use DigitalCraftsman\Ids\ValueObject\Exception\IdClassNotHandledInList;
+use DigitalCraftsman\Ids\ValueObject\Exception\IdListDoesContainEveryId;
 use DigitalCraftsman\Ids\ValueObject\Exception\IdListDoesContainId;
+use DigitalCraftsman\Ids\ValueObject\Exception\IdListDoesContainNoneIds;
 use DigitalCraftsman\Ids\ValueObject\Exception\IdListDoesNotContainEveryId;
 use DigitalCraftsman\Ids\ValueObject\Exception\IdListDoesNotContainId;
 use DigitalCraftsman\Ids\ValueObject\Exception\IdListDoesNotContainSomeIds;
@@ -326,6 +328,95 @@ final class OrderedIdListTest extends TestCase
         self::assertTrue($addedList->containsId($newId));
     }
 
+    // -- Add ids
+
+    /**
+     * @test
+     *
+     * @covers ::addIds
+     */
+    public function add_ids_works(): void
+    {
+        // -- Arrange
+        $idList = new OrderedUserIdList([
+            UserId::generateRandom(),
+            UserId::generateRandom(),
+        ]);
+
+        $newIds = new OrderedUserIdList([
+            UserId::generateRandom(),
+            UserId::generateRandom(),
+        ]);
+
+        // -- Act
+        $addedList = $idList->addIds($newIds);
+
+        // -- Assert
+        self::assertCount(2, $idList);
+        self::assertCount(4, $addedList);
+
+        self::assertTrue($addedList->containsEveryId($newIds));
+    }
+
+    /**
+     * @test
+     *
+     * @covers ::addIds
+     */
+    public function add_ids_fails_with_duplicate_id(): void
+    {
+        // -- Assert
+        $this->expectException(IdListDoesContainNoneIds::class);
+
+        // -- Arrange
+        $existingUserId = UserId::generateRandom();
+
+        $idList = new OrderedUserIdList([
+            $existingUserId,
+            UserId::generateRandom(),
+        ]);
+
+        $newIds = new OrderedUserIdList([
+            $existingUserId,
+            UserId::generateRandom(),
+        ]);
+
+        // -- Act
+        $idList->addIds($newIds);
+    }
+
+    /**
+     * @test
+     *
+     * @covers ::addIdsWhenNotInList
+     */
+    public function add_ids_when_not_in_list_works(): void
+    {
+        // -- Arrange
+        $existingId = UserId::generateRandom();
+        $idList = new OrderedUserIdList([
+            $existingId,
+            UserId::generateRandom(),
+        ]);
+
+        $newId = UserId::generateRandom();
+
+        $newIds = new OrderedUserIdList([
+            $existingId,
+            $newId,
+        ]);
+
+        // -- Act
+        $addedList = $idList->addIdsWhenNotInList($newIds);
+
+        // -- Assert
+        self::assertCount(2, $idList);
+        self::assertCount(3, $addedList);
+
+        self::assertTrue($addedList->containsId($existingId));
+        self::assertTrue($addedList->containsId($newId));
+    }
+
     // -- Remove id
 
     /**
@@ -346,6 +437,158 @@ final class OrderedIdListTest extends TestCase
 
         // -- Act
         $removedList = $idList->removeId($idToRemove);
+
+        // -- Assert
+        self::assertCount(3, $idList);
+        self::assertCount(2, $removedList);
+
+        self::assertTrue($removedList->notContainsId($idToRemove));
+    }
+
+    /**
+     * @test
+     *
+     * @covers ::removeId
+     */
+    public function remove_id_fails_when_id_is_not_in_list(): void
+    {
+        // -- Assert
+        $this->expectException(IdListDoesNotContainId::class);
+
+        // -- Arrange
+        $idToRemove = UserId::generateRandom();
+
+        $idList = new OrderedUserIdList([
+            UserId::generateRandom(),
+            UserId::generateRandom(),
+        ]);
+
+        // -- Act
+        $idList->removeId($idToRemove);
+    }
+
+    // Remove ids
+
+    /**
+     * @test
+     *
+     * @covers ::removeIds
+     */
+    public function remove_ids_works(): void
+    {
+        // -- Arrange
+        $idToRemove1 = UserId::generateRandom();
+        $idToRemove2 = UserId::generateRandom();
+
+        $idList = new OrderedUserIdList([
+            UserId::fromString((string) $idToRemove1),
+            UserId::fromString((string) $idToRemove2),
+            UserId::generateRandom(),
+            UserId::generateRandom(),
+        ]);
+
+        $idsToRemove = new OrderedUserIdList([
+            $idToRemove1,
+            $idToRemove2,
+        ]);
+
+        // -- Act
+        $removedList = $idList->removeIds($idsToRemove);
+
+        // -- Assert
+        self::assertCount(4, $idList);
+        self::assertCount(2, $removedList);
+
+        self::assertTrue($removedList->notContainsId($idToRemove1));
+        self::assertTrue($removedList->notContainsId($idToRemove2));
+    }
+
+    /**
+     * @test
+     *
+     * @covers ::removeIds
+     */
+    public function remove_ids_fails_when_id_is_not_in_list(): void
+    {
+        // -- Assert
+        $this->expectException(IdListDoesNotContainEveryId::class);
+
+        // -- Arrange
+        $idToRemove1 = UserId::generateRandom();
+        $idToRemove2 = UserId::generateRandom();
+
+        $idList = new OrderedUserIdList([
+            $idToRemove1,
+            UserId::generateRandom(),
+            UserId::generateRandom(),
+        ]);
+
+        $idsToRemove = new OrderedUserIdList([
+            $idToRemove1,
+            $idToRemove2,
+        ]);
+
+        // -- Act
+        $idList->removeIds($idsToRemove);
+    }
+
+    /**
+     * @test
+     *
+     * @covers ::removeIdsWhenInList
+     */
+    public function remove_ids_when_in_list_works(): void
+    {
+        // -- Arrange
+        $idToRemove1 = UserId::generateRandom();
+        $idToRemove2 = UserId::generateRandom();
+        $idToRemove3 = UserId::generateRandom();
+
+        $idList = new OrderedUserIdList([
+            UserId::fromString((string) $idToRemove1),
+            UserId::fromString((string) $idToRemove2),
+            UserId::generateRandom(),
+            UserId::generateRandom(),
+        ]);
+
+        $idsToRemove = new OrderedUserIdList([
+            $idToRemove1,
+            $idToRemove2,
+            $idToRemove3,
+        ]);
+
+        // -- Act
+        $removedList = $idList->removeIdsWhenInList($idsToRemove);
+
+        // -- Assert
+        self::assertCount(4, $idList);
+        self::assertCount(2, $removedList);
+
+        self::assertTrue($removedList->notContainsId($idToRemove1));
+        self::assertTrue($removedList->notContainsId($idToRemove2));
+    }
+
+    /**
+     * @test
+     *
+     * @covers ::removeIdWhenInList
+     */
+    public function remove_id_when_in_list_works(): void
+    {
+        // -- Arrange
+        $idToRemove = UserId::generateRandom();
+
+        $idList = new OrderedUserIdList([
+            $idToRemove,
+            UserId::generateRandom(),
+            UserId::generateRandom(),
+        ]);
+
+        $idNotInList = UserId::generateRandom();
+
+        // -- Act
+        $removedList = $idList->removeIdWhenInList($idToRemove);
+        $removedList = $removedList->removeIdWhenInList($idNotInList);
 
         // -- Assert
         self::assertCount(3, $idList);
@@ -599,6 +842,59 @@ final class OrderedIdListTest extends TestCase
     /**
      * @test
      *
+     * @covers ::mustNotContainEveryId
+     */
+    public function id_list_must_not_contain_every_id(): void
+    {
+        // -- Assert
+        $this->expectException(IdListDoesContainEveryId::class);
+
+        // -- Arrange
+        $idAnton = UserId::generateRandom();
+        $idPaul = UserId::generateRandom();
+
+        $fullList = OrderedUserIdList::fromIds([
+            clone $idAnton,
+            clone $idPaul,
+        ]);
+
+        $partialList = OrderedUserIdList::fromIds([
+            clone $idAnton,
+        ]);
+
+        // -- Act
+        $fullList->mustNotContainEveryId($partialList);
+    }
+
+    /**
+     * @test
+     *
+     * @covers ::mustNotContainEveryId
+     *
+     * @doesNotPerformAssertions
+     */
+    public function id_list_must_not_contain_every_id_when_every_id_is_present(): void
+    {
+        // -- Arrange
+        $idAnton = UserId::generateRandom();
+        $idPaul = UserId::generateRandom();
+
+        $fullList = OrderedUserIdList::fromIds([
+            clone $idAnton,
+            clone $idPaul,
+        ]);
+
+        $partialList = OrderedUserIdList::fromIds([
+            clone $idAnton,
+        ]);
+
+        // -- Act & Assert
+        $partialList->mustNotContainEveryId($fullList);
+    }
+
+    /**
+     * @test
+     *
      * @covers ::mustContainSomeIds
      */
     public function id_list_must_contain_some_ids(): void
@@ -652,6 +948,64 @@ final class OrderedIdListTest extends TestCase
 
         // -- Act & Assert
         $almostFullList->mustContainSomeIds($idListWithDifferentId);
+    }
+
+    /**
+     * @test
+     *
+     * @covers ::mustContainNoneIds
+     */
+    public function id_list_must_contain_none_ids(): void
+    {
+        // -- Assert
+        $this->expectException(IdListDoesContainNoneIds::class);
+
+        // -- Arrange
+        $idAnton = UserId::generateRandom();
+        $idPaul = UserId::generateRandom();
+
+        $idPeter = UserId::generateRandom();
+
+        $almostFullList = OrderedUserIdList::fromIds([
+            clone $idAnton,
+            clone $idPaul,
+        ]);
+
+        $idListWithPartialMatchingIds = OrderedUserIdList::fromIds([
+            clone $idPeter,
+            clone $idPaul,
+        ]);
+
+        // -- Act
+        $idListWithPartialMatchingIds->mustContainNoneIds($almostFullList);
+    }
+
+    /**
+     * @test
+     *
+     * @covers ::mustContainNoneIds
+     *
+     * @doesNotPerformAssertions
+     */
+    public function id_list_must_contain_none_ids_when_no_id_is_available(): void
+    {
+        // -- Arrange
+        $idAnton = UserId::generateRandom();
+        $idPaul = UserId::generateRandom();
+
+        $idPeter = UserId::generateRandom();
+
+        $almostFullList = OrderedUserIdList::fromIds([
+            clone $idAnton,
+            clone $idPaul,
+        ]);
+
+        $idListWithDifferentId = OrderedUserIdList::fromIds([
+            clone $idPeter,
+        ]);
+
+        // -- Act & Assert
+        $almostFullList->mustContainNoneIds($idListWithDifferentId);
     }
 
     // -- Must be empty
@@ -1012,6 +1366,48 @@ final class OrderedIdListTest extends TestCase
         self::assertFalse($partialList->containsEveryId($listWithDifferentId));
     }
 
+    /**
+     * @test
+     *
+     * @covers ::notContainsEveryId
+     */
+    public function id_list_not_contains_every_id_works(): void
+    {
+        // -- Arrange
+        $idAnton = UserId::generateRandom();
+        $idMarkus = UserId::generateRandom();
+        $idPaul = UserId::generateRandom();
+        $idTom = UserId::generateRandom();
+
+        $idPeter = UserId::generateRandom();
+
+        // Generate new ids to make sure that it's enough for ids to be equal instead of same instance.
+        $listWithAlmostAllIds = OrderedUserIdList::fromIds([
+            clone $idAnton,
+            clone $idMarkus,
+            clone $idPaul,
+            clone $idTom,
+        ]);
+
+        $partialList = OrderedUserIdList::fromIds([
+            clone $idAnton,
+            clone $idPaul,
+        ]);
+
+        $listWithDifferentId = OrderedUserIdList::fromIds([
+            clone $idAnton,
+            clone $idPaul,
+            clone $idPeter,
+        ]);
+
+        // -- Act & Assert
+        self::assertFalse($listWithAlmostAllIds->notContainsEveryId($partialList));
+        self::assertTrue($partialList->notContainsEveryId($listWithAlmostAllIds));
+
+        self::assertTrue($listWithAlmostAllIds->notContainsEveryId($listWithDifferentId));
+        self::assertTrue($partialList->notContainsEveryId($listWithDifferentId));
+    }
+
     // -- Contains some ids
 
     /**
@@ -1061,6 +1457,55 @@ final class OrderedIdListTest extends TestCase
 
         self::assertFalse($listWithAlmostAllIds->containsSomeIds($listWithOnlyDifferentIds));
         self::assertFalse($partialList->containsSomeIds($listWithOnlyDifferentIds));
+    }
+
+    /**
+     * @test
+     *
+     * @covers ::containsNoneIds
+     */
+    public function id_list_contains_none_ids_works(): void
+    {
+        // -- Arrange
+        $idAnton = UserId::generateRandom();
+        $idMarkus = UserId::generateRandom();
+        $idPaul = UserId::generateRandom();
+        $idTom = UserId::generateRandom();
+
+        $idPeter = UserId::generateRandom();
+
+        // Generate new ids to make sure that it's enough for ids to be equal instead of same instance.
+        $listWithAlmostAllIds = OrderedUserIdList::fromIds([
+            clone $idAnton,
+            clone $idMarkus,
+            clone $idPaul,
+            clone $idTom,
+        ]);
+
+        $partialList = OrderedUserIdList::fromIds([
+            clone $idAnton,
+            clone $idPaul,
+        ]);
+
+        $listWithDifferentId = OrderedUserIdList::fromIds([
+            clone $idAnton,
+            clone $idPaul,
+            clone $idPeter,
+        ]);
+
+        $listWithOnlyDifferentIds = OrderedUserIdList::fromIds([
+            clone $idPeter,
+        ]);
+
+        // -- Act & Assert
+        self::assertFalse($listWithAlmostAllIds->containsNoneIds($partialList));
+        self::assertFalse($partialList->containsNoneIds($listWithAlmostAllIds));
+
+        self::assertFalse($listWithAlmostAllIds->containsNoneIds($listWithDifferentId));
+        self::assertFalse($partialList->containsNoneIds($listWithDifferentId));
+
+        self::assertTrue($listWithAlmostAllIds->containsNoneIds($listWithOnlyDifferentIds));
+        self::assertTrue($partialList->containsNoneIds($listWithOnlyDifferentIds));
     }
 
     // -- Is equal and not equal

--- a/tests/ValueObject/OrderedIdListTest.php
+++ b/tests/ValueObject/OrderedIdListTest.php
@@ -137,15 +137,39 @@ final class OrderedIdListTest extends TestCase
      */
     public function id_list_construction_from_ids_works(): void
     {
-        // -- Arrange & Act
-        $idList = OrderedUserIdList::fromIds([
+        // -- Arrange
+        $ids = [
             UserId::generateRandom(),
             UserId::generateRandom(),
             UserId::generateRandom(),
-        ]);
+        ];
+
+        // -- Act
+        $idList = OrderedUserIdList::fromIds($ids);
 
         // -- Assert
-        self::assertCount(3, $idList->ids);
+        self::assertCount(3, $idList);
+    }
+
+    /**
+     * @test
+     *
+     * @covers ::fromIdStrings
+     */
+    public function id_list_construction_from_id_strings_works(): void
+    {
+        // -- Arrange
+        $idStrings = [
+            (string) UserId::generateRandom(),
+            (string) UserId::generateRandom(),
+            (string) UserId::generateRandom(),
+        ];
+
+        // -- Act
+        $idList = OrderedUserIdList::fromIdStrings($idStrings);
+
+        // -- Assert
+        self::assertCount(3, $idList);
     }
 
     /**

--- a/tests/ValueObject/OrderedIdListTest.php
+++ b/tests/ValueObject/OrderedIdListTest.php
@@ -9,7 +9,6 @@ use DigitalCraftsman\Ids\Test\ValueObject\InstructorId;
 use DigitalCraftsman\Ids\Test\ValueObject\OrderedUserIdList;
 use DigitalCraftsman\Ids\Test\ValueObject\ProjectId;
 use DigitalCraftsman\Ids\Test\ValueObject\UserId;
-use DigitalCraftsman\Ids\Test\ValueObject\UserIdList;
 use DigitalCraftsman\Ids\ValueObject\Exception\DuplicateIds;
 use DigitalCraftsman\Ids\ValueObject\Exception\IdAlreadyInList;
 use DigitalCraftsman\Ids\ValueObject\Exception\IdClassNotHandledInList;

--- a/tests/ValueObject/OrderedIdListTest.php
+++ b/tests/ValueObject/OrderedIdListTest.php
@@ -6,6 +6,7 @@ namespace DigitalCraftsman\Ids\ValueObject;
 
 use DigitalCraftsman\Ids\Test\ValueObject\AdminId;
 use DigitalCraftsman\Ids\Test\ValueObject\InstructorId;
+use DigitalCraftsman\Ids\Test\ValueObject\OrderedUserIdList;
 use DigitalCraftsman\Ids\Test\ValueObject\ProjectId;
 use DigitalCraftsman\Ids\Test\ValueObject\UserId;
 use DigitalCraftsman\Ids\Test\ValueObject\UserIdList;
@@ -20,8 +21,8 @@ use DigitalCraftsman\Ids\ValueObject\Exception\IdListIsNotEmpty;
 use DigitalCraftsman\Ids\ValueObject\Exception\IdListsMustBeEqual;
 use PHPUnit\Framework\TestCase;
 
-/** @coversDefaultClass \DigitalCraftsman\Ids\ValueObject\IdList */
-final class IdListTest extends TestCase
+/** @coversDefaultClass \DigitalCraftsman\Ids\ValueObject\OrderedIdList */
+final class OrderedIdListTest extends TestCase
 {
     // -- Construct
 
@@ -33,7 +34,7 @@ final class IdListTest extends TestCase
     public function id_list_construction_works(): void
     {
         // -- Arrange & Act
-        $idList = new UserIdList([
+        $idList = new OrderedUserIdList([
             UserId::generateRandom(),
             UserId::generateRandom(),
             UserId::generateRandom(),
@@ -51,7 +52,7 @@ final class IdListTest extends TestCase
     public function id_list_construction_works_with_index_that_is_not_a_list(): void
     {
         // -- Arrange & Act
-        $idList = new UserIdList([
+        $idList = new OrderedUserIdList([
             0 => UserId::generateRandom(),
             2 => UserId::generateRandom(),
             33 => UserId::generateRandom(),
@@ -74,7 +75,7 @@ final class IdListTest extends TestCase
     public function id_list_construction_works_with_ids_of_subclass(): void
     {
         // -- Arrange & Act
-        new UserIdList([
+        new OrderedUserIdList([
             UserId::generateRandom(),
             UserId::generateRandom(),
             InstructorId::generateRandom(),
@@ -96,7 +97,7 @@ final class IdListTest extends TestCase
         // -- Arrange & Act
         $duplicateId = UserId::generateRandom();
 
-        new UserIdList([
+        new OrderedUserIdList([
             $duplicateId,
             $duplicateId,
             UserId::generateRandom(),
@@ -122,7 +123,7 @@ final class IdListTest extends TestCase
          *
          * @phpstan-ignore-next-line
          */
-        new UserIdList([
+        new OrderedUserIdList([
             UserId::generateRandom(),
             UserId::generateRandom(),
             UserId::generateRandom(),
@@ -140,7 +141,7 @@ final class IdListTest extends TestCase
     public function id_list_construction_from_ids_works(): void
     {
         // -- Arrange & Act
-        UserIdList::fromIds([
+        OrderedUserIdList::fromIds([
             UserId::generateRandom(),
             UserId::generateRandom(),
             UserId::generateRandom(),
@@ -155,7 +156,7 @@ final class IdListTest extends TestCase
     public function empty_list_works(): void
     {
         // -- Arrange
-        $emptyIdList = UserIdList::emptyList();
+        $emptyIdList = OrderedUserIdList::emptyList();
 
         // -- Act & Assert
         self::assertCount(0, $emptyIdList);
@@ -171,20 +172,20 @@ final class IdListTest extends TestCase
     public function from_id_lists_works(): void
     {
         // -- Arrange
-        $idList1 = new UserIdList([
+        $idList1 = new OrderedUserIdList([
             UserId::generateRandom(),
             UserId::generateRandom(),
             UserId::generateRandom(),
         ]);
 
-        $idList2 = new UserIdList([
+        $idList2 = new OrderedUserIdList([
             UserId::generateRandom(),
             UserId::generateRandom(),
             UserId::generateRandom(),
         ]);
 
         // -- Act
-        $mergedIdList = UserIdList::fromIdLists([
+        $mergedIdList = OrderedUserIdList::fromIdLists([
             $idList1,
             $idList2,
         ]);
@@ -201,20 +202,20 @@ final class IdListTest extends TestCase
     public function from_id_lists_with_duplicates_works(): void
     {
         // -- Arrange
-        $idList1 = new UserIdList([
+        $idList1 = new OrderedUserIdList([
             new UserId('41918847-b781-4046-94ce-2fddf5674d9e'),
             UserId::generateRandom(),
             UserId::generateRandom(),
         ]);
 
-        $idList2 = new UserIdList([
+        $idList2 = new OrderedUserIdList([
             new UserId('41918847-b781-4046-94ce-2fddf5674d9e'),
             UserId::generateRandom(),
             UserId::generateRandom(),
         ]);
 
         // -- Act
-        $mergedIdList = UserIdList::fromIdLists([
+        $mergedIdList = OrderedUserIdList::fromIdLists([
             $idList1,
             $idList2,
         ]);
@@ -233,7 +234,7 @@ final class IdListTest extends TestCase
     public function add_id_works(): void
     {
         // -- Arrange
-        $idList = new UserIdList([
+        $idList = new OrderedUserIdList([
             UserId::generateRandom(),
             UserId::generateRandom(),
         ]);
@@ -262,7 +263,7 @@ final class IdListTest extends TestCase
 
         // -- Arrange
         $existingUserId = UserId::generateRandom();
-        $idList = new UserIdList([
+        $idList = new OrderedUserIdList([
             $existingUserId,
             UserId::generateRandom(),
         ]);
@@ -280,7 +281,7 @@ final class IdListTest extends TestCase
     {
         // -- Arrange
         $existingId = UserId::generateRandom();
-        $idList = new UserIdList([
+        $idList = new OrderedUserIdList([
             $existingId,
             UserId::generateRandom(),
         ]);
@@ -313,7 +314,7 @@ final class IdListTest extends TestCase
         // -- Arrange
         $idToRemove = UserId::generateRandom();
 
-        $idList = new UserIdList([
+        $idList = new OrderedUserIdList([
             $idToRemove,
             UserId::generateRandom(),
             UserId::generateRandom(),
@@ -344,14 +345,14 @@ final class IdListTest extends TestCase
         $idPaul = UserId::generateRandom();
         $idTom = UserId::generateRandom();
 
-        $originalList = UserIdList::fromIds([
+        $originalList = OrderedUserIdList::fromIds([
             $idAnton,
             $idMarkus,
             $idPaul,
             $idTom,
         ]);
 
-        $partialList = UserIdList::fromIds([
+        $partialList = OrderedUserIdList::fromIds([
             $idAnton,
             $idPaul,
         ]);
@@ -381,14 +382,14 @@ final class IdListTest extends TestCase
         $idPaul = UserId::generateRandom();
         $idTom = UserId::generateRandom();
 
-        $originalList = UserIdList::fromIds([
+        $originalList = OrderedUserIdList::fromIds([
             $idAnton,
             $idMarkus,
             $idPaul,
             $idTom,
         ]);
 
-        $emptyList = UserIdList::emptyList();
+        $emptyList = OrderedUserIdList::emptyList();
 
         // -- Act
         $diffListFromOriginal = $originalList->diff($emptyList);
@@ -414,14 +415,14 @@ final class IdListTest extends TestCase
         $idPaul = UserId::generateRandom();
         $idTom = UserId::generateRandom();
 
-        $fullList = UserIdList::fromIds([
+        $fullList = OrderedUserIdList::fromIds([
             $idAnton,
             $idMarkus,
             $idPaul,
             $idTom,
         ]);
 
-        $partialList = UserIdList::fromIds([
+        $partialList = OrderedUserIdList::fromIds([
             $idAnton,
             $idPaul,
         ]);
@@ -454,14 +455,14 @@ final class IdListTest extends TestCase
         $idPaul = UserId::generateRandom();
         $idTom = UserId::generateRandom();
 
-        $listWithAllIds = UserIdList::fromIds([
+        $listWithAllIds = OrderedUserIdList::fromIds([
             $idAnton,
             $idMarkus,
             $idPaul,
             $idTom,
         ]);
 
-        $partialList = UserIdList::fromIds([
+        $partialList = OrderedUserIdList::fromIds([
             $idAnton,
             $idPaul,
         ]);
@@ -486,7 +487,7 @@ final class IdListTest extends TestCase
         $idMarkus = UserId::generateRandom();
         $idPaul = UserId::generateRandom();
 
-        $partialList = UserIdList::fromIds([
+        $partialList = OrderedUserIdList::fromIds([
             $idAnton,
             $idPaul,
         ]);
@@ -509,7 +510,7 @@ final class IdListTest extends TestCase
         $idAnton = UserId::generateRandom();
         $idPaul = UserId::generateRandom();
 
-        $partialList = UserIdList::fromIds([
+        $partialList = OrderedUserIdList::fromIds([
             $idAnton,
             $idPaul,
         ]);
@@ -532,12 +533,12 @@ final class IdListTest extends TestCase
         $idAnton = UserId::generateRandom();
         $idPaul = UserId::generateRandom();
 
-        $fullList = UserIdList::fromIds([
+        $fullList = OrderedUserIdList::fromIds([
             clone $idAnton,
             clone $idPaul,
         ]);
 
-        $partialList = UserIdList::fromIds([
+        $partialList = OrderedUserIdList::fromIds([
             clone $idAnton,
         ]);
 
@@ -558,12 +559,12 @@ final class IdListTest extends TestCase
         $idAnton = UserId::generateRandom();
         $idPaul = UserId::generateRandom();
 
-        $fullList = UserIdList::fromIds([
+        $fullList = OrderedUserIdList::fromIds([
             clone $idAnton,
             clone $idPaul,
         ]);
 
-        $partialList = UserIdList::fromIds([
+        $partialList = OrderedUserIdList::fromIds([
             clone $idAnton,
         ]);
 
@@ -587,12 +588,12 @@ final class IdListTest extends TestCase
 
         $idPeter = UserId::generateRandom();
 
-        $almostFullList = UserIdList::fromIds([
+        $almostFullList = OrderedUserIdList::fromIds([
             clone $idAnton,
             clone $idPaul,
         ]);
 
-        $idListWithDifferentId = UserIdList::fromIds([
+        $idListWithDifferentId = OrderedUserIdList::fromIds([
             clone $idPeter,
         ]);
 
@@ -615,12 +616,12 @@ final class IdListTest extends TestCase
 
         $idPeter = UserId::generateRandom();
 
-        $almostFullList = UserIdList::fromIds([
+        $almostFullList = OrderedUserIdList::fromIds([
             clone $idAnton,
             clone $idPaul,
         ]);
 
-        $idListWithDifferentId = UserIdList::fromIds([
+        $idListWithDifferentId = OrderedUserIdList::fromIds([
             clone $idPaul,
             clone $idPeter,
         ]);
@@ -641,7 +642,7 @@ final class IdListTest extends TestCase
     public function id_list_must_be_empty_works(): void
     {
         // -- Arrange
-        $emptyList = UserIdList::emptyList();
+        $emptyList = OrderedUserIdList::emptyList();
 
         // -- Act
         $emptyList->mustBeEmpty();
@@ -658,7 +659,7 @@ final class IdListTest extends TestCase
         $this->expectException(IdListIsNotEmpty::class);
 
         // -- Arrange
-        $notEmptyList = new UserIdList([
+        $notEmptyList = new OrderedUserIdList([
             UserId::generateRandom(),
         ]);
 
@@ -677,8 +678,8 @@ final class IdListTest extends TestCase
     public function id_list_is_empty_works(): void
     {
         // -- Arrange
-        $emptyList = UserIdList::emptyList();
-        $notEmptyList = new UserIdList([
+        $emptyList = OrderedUserIdList::emptyList();
+        $notEmptyList = new OrderedUserIdList([
             UserId::generateRandom(),
         ]);
 
@@ -705,7 +706,7 @@ final class IdListTest extends TestCase
         $idPaul = UserId::generateRandom();
         $idTom = UserId::generateRandom();
 
-        $listWithAllIds = UserIdList::fromIds([
+        $listWithAllIds = OrderedUserIdList::fromIds([
             $idAnton,
             $idMarkus,
             $idPaul,
@@ -744,14 +745,14 @@ final class IdListTest extends TestCase
         $idPaul = UserId::generateRandom();
         $idTom = UserId::generateRandom();
 
-        $listWithAllIds = UserIdList::fromIds([
+        $listWithAllIds = OrderedUserIdList::fromIds([
             $idAnton,
             $idMarkus,
             $idPaul,
             $idTom,
         ]);
 
-        $externalIdsToMatch = UserIdList::fromIds([
+        $externalIdsToMatch = OrderedUserIdList::fromIds([
             $idAnton,
             $idTom,
         ]);
@@ -787,19 +788,19 @@ final class IdListTest extends TestCase
 
         $idChris = UserId::generateRandom();
 
-        $listWithAllIdsOfGroupSparta = UserIdList::fromIds([
+        $listWithAllIdsOfGroupSparta = OrderedUserIdList::fromIds([
             $idAnton,
             $idMarkus,
             $idPaul,
             $idTom,
         ]);
 
-        $listWithIdsThatAreAllInGroupSparta = UserIdList::fromIds([
+        $listWithIdsThatAreAllInGroupSparta = OrderedUserIdList::fromIds([
             $idAnton,
             $idTom,
         ]);
 
-        $listWithIdsThatAreNotAllInGroupSparta = UserIdList::fromIds([
+        $listWithIdsThatAreNotAllInGroupSparta = OrderedUserIdList::fromIds([
             $idAnton,
             $idTom,
             $idChris,
@@ -836,20 +837,20 @@ final class IdListTest extends TestCase
         $idChris = UserId::generateRandom();
         $idQuirin = UserId::generateRandom();
 
-        $listWithAllIdsOfGroupSparta = UserIdList::fromIds([
+        $listWithAllIdsOfGroupSparta = OrderedUserIdList::fromIds([
             $idAnton,
             $idMarkus,
             $idPaul,
             $idTom,
         ]);
 
-        $listWithIdsThatContainSomeOfSpartaGroup = UserIdList::fromIds([
+        $listWithIdsThatContainSomeOfSpartaGroup = OrderedUserIdList::fromIds([
             $idAnton,
             $idTom,
             $idChris,
         ]);
 
-        $listWithIdsThatContainNoneOfSpartaGroup = UserIdList::fromIds([
+        $listWithIdsThatContainNoneOfSpartaGroup = OrderedUserIdList::fromIds([
             $idChris,
             $idQuirin,
         ]);
@@ -889,7 +890,7 @@ final class IdListTest extends TestCase
             (string) $idTom => 17,
         ];
 
-        $listWithIdsOfAllUsers = UserIdList::fromIds([
+        $listWithIdsOfAllUsers = OrderedUserIdList::fromIds([
             $idAnton,
             $idMarkus,
             $idPaul,
@@ -923,14 +924,14 @@ final class IdListTest extends TestCase
         $idTom = UserId::generateRandom();
 
         // Generate new ids to make sure that it's enough for ids to be equal instead of same instance.
-        $listWithAllIds = UserIdList::fromIds([
+        $listWithAllIds = OrderedUserIdList::fromIds([
             UserId::fromString((string) $idAnton),
             UserId::fromString((string) $idMarkus),
             UserId::fromString((string) $idPaul),
             UserId::fromString((string) $idTom),
         ]);
 
-        $partialList = UserIdList::fromIds([
+        $partialList = OrderedUserIdList::fromIds([
             $idAnton,
             $idPaul,
         ]);
@@ -961,19 +962,19 @@ final class IdListTest extends TestCase
         $idPeter = UserId::generateRandom();
 
         // Generate new ids to make sure that it's enough for ids to be equal instead of same instance.
-        $listWithAlmostAllIds = UserIdList::fromIds([
+        $listWithAlmostAllIds = OrderedUserIdList::fromIds([
             clone $idAnton,
             clone $idMarkus,
             clone $idPaul,
             clone $idTom,
         ]);
 
-        $partialList = UserIdList::fromIds([
+        $partialList = OrderedUserIdList::fromIds([
             clone $idAnton,
             clone $idPaul,
         ]);
 
-        $listWithDifferentId = UserIdList::fromIds([
+        $listWithDifferentId = OrderedUserIdList::fromIds([
             clone $idAnton,
             clone $idPaul,
             clone $idPeter,
@@ -1005,25 +1006,25 @@ final class IdListTest extends TestCase
         $idPeter = UserId::generateRandom();
 
         // Generate new ids to make sure that it's enough for ids to be equal instead of same instance.
-        $listWithAlmostAllIds = UserIdList::fromIds([
+        $listWithAlmostAllIds = OrderedUserIdList::fromIds([
             clone $idAnton,
             clone $idMarkus,
             clone $idPaul,
             clone $idTom,
         ]);
 
-        $partialList = UserIdList::fromIds([
+        $partialList = OrderedUserIdList::fromIds([
             clone $idAnton,
             clone $idPaul,
         ]);
 
-        $listWithDifferentId = UserIdList::fromIds([
+        $listWithDifferentId = OrderedUserIdList::fromIds([
             clone $idAnton,
             clone $idPaul,
             clone $idPeter,
         ]);
 
-        $listWithOnlyDifferentIds = UserIdList::fromIds([
+        $listWithOnlyDifferentIds = OrderedUserIdList::fromIds([
             clone $idPeter,
         ]);
 
@@ -1056,26 +1057,26 @@ final class IdListTest extends TestCase
 
         $idMarc = UserId::generateRandom();
 
-        $originalList = UserIdList::fromIds([
+        $originalList = OrderedUserIdList::fromIds([
             clone $idAnton,
             clone $idMarkus,
             clone $idPaul,
             clone $idTom,
         ]);
 
-        $copyOfOriginalList = UserIdList::fromIds([
+        $copyOfOriginalList = OrderedUserIdList::fromIds([
             clone $idAnton,
             clone $idMarkus,
             clone $idPaul,
             clone $idTom,
         ]);
 
-        $partialList = UserIdList::fromIds([
+        $partialList = OrderedUserIdList::fromIds([
             clone $idAnton,
             clone $idPaul,
         ]);
 
-        $listWithOneExchanged = UserIdList::fromIds([
+        $listWithOneExchanged = OrderedUserIdList::fromIds([
             clone $idAnton,
             clone $idMarkus,
             clone $idPaul,
@@ -1103,8 +1104,8 @@ final class IdListTest extends TestCase
         $idTom = UserId::generateRandom();
         $idMarkus = UserId::generateRandom();
 
-        $emptyIdList = UserIdList::fromIds([]);
-        $userIdList = UserIdList::fromIds([
+        $emptyIdList = OrderedUserIdList::fromIds([]);
+        $userIdList = OrderedUserIdList::fromIds([
             $idTom,
             $idMarkus,
         ]);
@@ -1127,8 +1128,8 @@ final class IdListTest extends TestCase
         $idTom = UserId::generateRandom();
         $idMarkus = UserId::generateRandom();
 
-        $emptyIdList = UserIdList::fromIds([]);
-        $userIdList = UserIdList::fromIds([
+        $emptyIdList = OrderedUserIdList::fromIds([]);
+        $userIdList = OrderedUserIdList::fromIds([
             $idTom,
             $idMarkus,
         ]);
@@ -1155,14 +1156,14 @@ final class IdListTest extends TestCase
         $idPaul = UserId::generateRandom();
         $idTom = UserId::generateRandom();
 
-        $originalList = UserIdList::fromIds([
+        $originalList = OrderedUserIdList::fromIds([
             $idAnton,
             $idMarkus,
             $idPaul,
             $idTom,
         ]);
 
-        $partialList = UserIdList::fromIds([
+        $partialList = OrderedUserIdList::fromIds([
             $idAnton,
             $idPaul,
         ]);
@@ -1181,7 +1182,7 @@ final class IdListTest extends TestCase
     public function id_list_count_works(): void
     {
         // -- Arrange
-        $idList = new UserIdList([
+        $idList = new OrderedUserIdList([
             UserId::generateRandom(),
             UserId::generateRandom(),
             UserId::generateRandom(),
@@ -1205,13 +1206,13 @@ final class IdListTest extends TestCase
         $idMarkus = UserId::generateRandom();
         $idPaul = UserId::generateRandom();
 
-        $idList = new UserIdList([
+        $idList = new OrderedUserIdList([
             $idAnton,
             $idMarkus,
             $idPaul,
         ]);
 
-        $duplicatedIdList = new UserIdList([
+        $duplicatedIdList = new OrderedUserIdList([
             $idAnton,
             $idMarkus,
             $idPaul,
@@ -1253,7 +1254,7 @@ final class IdListTest extends TestCase
         $idMarkus = UserId::generateRandom();
         $idPaul = UserId::generateRandom();
 
-        $idList = new UserIdList([
+        $idList = new OrderedUserIdList([
             0 => $idAnton,
             1 => $idMarkus,
             3 => $idPaul,
@@ -1276,6 +1277,45 @@ final class IdListTest extends TestCase
         self::assertSame($expectedString, $concatenatedIds);
     }
 
+    /**
+     * @test
+     *
+     * @covers ::isInSameOrder
+     * @covers ::idAtPosition
+     * @covers ::intersect
+     */
+    public function id_list_is_in_same_order_works(): void
+    {
+        // -- Arrange
+        $idAnton = UserId::generateRandom();
+        $idMarkus = UserId::generateRandom();
+        $idPaul = UserId::generateRandom();
+        $idTom = UserId::generateRandom();
+
+        // Ordered alphabetically
+        $orderedIdList = OrderedUserIdList::fromIds([
+            $idAnton,
+            $idMarkus,
+            $idPaul,
+            $idTom,
+        ]);
+
+        // In order but with missing ids
+        $idListThatIsInOrder = OrderedUserIdList::fromIds([
+            $idAnton,
+            $idPaul,
+        ]);
+
+        $idListThatIsNotInOrder = OrderedUserIdList::fromIds([
+            $idPaul,
+            $idMarkus,
+        ]);
+
+        // -- Act & Assert
+        self::assertTrue($idListThatIsInOrder->isInSameOrder($orderedIdList));
+        self::assertFalse($idListThatIsNotInOrder->isInSameOrder($orderedIdList));
+    }
+
     // -- Ids as string
 
     /**
@@ -1291,7 +1331,7 @@ final class IdListTest extends TestCase
         $idPaul = UserId::generateRandom();
         $idTom = UserId::generateRandom();
 
-        $orderedIdList = UserIdList::fromIds([
+        $orderedIdList = OrderedUserIdList::fromIds([
             $idAnton,
             $idMarkus,
             $idPaul,


### PR DESCRIPTION
## Changes

- New default list that is more performant for larger sets of ids but uses string indexes.
- A new `OrderedIdList` works the previous way and still includes the `isInSameOrder` method.
