### PR TITLE
Added multiple transformation methods to IdList and streamlined removeId

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@
 - Added new method `addIdsWhenNotInList(self $idList): static` to `IdList`.
 - Added new method `removeIds(self $idList): static` to `IdList`.
 - Added new method `removeIdsWhenInList(self $idList): static` to `IdList`.
+- Added new method `notContainsEveryId(self $idList): bool` to `IdList`.
+- Added new method `containsNoneIds(self $idList): bool` to `IdList`.
+- Added new method `mustNotContainEveryId(self $idList): void` to `IdList`.
+- Added new method `mustContainNoneIds(self $idList): void` to `IdList`.
 - Added new named constructor `fromIdStrings` to `IdList`.
 
 ## 0.7.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,11 +3,11 @@
 ## 0.8.0
 
 - **[Breaking change](./UPGRADE.md#updated-behaviour-of-idlistremoveid)**: Updated method `removeId` from `IdList` to throw an exception when the id is not in the list. This is the same behaviour as the `addId` method has.
-- Added new method `removeIdWhenInList` to `IdList`.
-- Added new method `addIds` to `IdList`.
-- Added new method `addIdsWhenNotInList` to `IdList`.
-- Added new method `removeIds` to `IdList`.
-- Added new method `removeIdsWhenInList` to `IdList`.
+- Added new method `removeIdWhenInList(Id $id): static` to `IdList`.
+- Added new method `addIds(self $idList): static` to `IdList`.
+- Added new method `addIdsWhenNotInList(self $idList): static` to `IdList`.
+- Added new method `removeIds(self $idList): static` to `IdList`.
+- Added new method `removeIdsWhenInList(self $idList): static` to `IdList`.
 - Added new named constructor `fromIdStrings` to `IdList`.
 
 ## 0.7.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,11 +2,13 @@
 
 ## 0.8.0
 
+- **[Breaking change](./UPGRADE.md#updated-behaviour-of-idlistremoveid)**: Updated method `removeId` from `IdList` to throw an exception when the id is not in the list. This is the same behaviour as the `addId` method has.
+- Added new method `removeIdWhenInList` to `IdList`.
 - Added new `fromIdStrings` named constructor to `IdList`.
 
 ## 0.7.0
 
-- Changed the way `IdList`'s `diff` method behaves to match `array_diff`'s behavior.
+- **[Breaking change](./UPGRADE.md#updated-behaviour-of-idlistdiff)**: Changed the way `IdList`'s `diff` method behaves to match `array_diff`'s behavior.
   - Previously it returned an `IdList` containing all elements that were present in the `IdList` itself but not in the given `IdList` (method parameter) as well as all elements that were in the given `IdList` (method parameter) but not in the `IdList` itself.
   - Now it returns an `IdList` containing only the elements that are present in the `IdList` itself but not in the given `IdList` (method parameter).
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,11 @@
 
 - **[Breaking change](./UPGRADE.md#updated-behaviour-of-idlistremoveid)**: Updated method `removeId` from `IdList` to throw an exception when the id is not in the list. This is the same behaviour as the `addId` method has.
 - Added new method `removeIdWhenInList` to `IdList`.
-- Added new `fromIdStrings` named constructor to `IdList`.
+- Added new method `addIds` to `IdList`.
+- Added new method `addIdsWhenNotInList` to `IdList`.
+- Added new method `removeIds` to `IdList`.
+- Added new method `removeIdsWhenInList` to `IdList`.
+- Added new named constructor `fromIdStrings` to `IdList`.
 
 ## 0.7.0
 

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -2,11 +2,13 @@
 
 ## From 0.7.* to 0.8.0
 
-No breaking changes, only added features.
+### Updated behaviour of `IdList::removeId`
+
+The `removeId` method of `IdList` now behaves like the `addId` method in that it throws an exception (`IdListDoesNotContainId`) when the id that has to be removed, doesn't exist in the list. Use the new `removeIdWhenInList` method if you want to remove an id without caring whether it's in the list or not.
 
 ## From 0.6.* to 0.7.0
 
-### Updated diff behaviour
+### Updated behaviour of `IdList::diff`
 
 The `diff` method of `IdList` now behaves like `array_diff`.
 

--- a/src/ValueObject/Exception/IdListDoesContainEveryId.php
+++ b/src/ValueObject/Exception/IdListDoesContainEveryId.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DigitalCraftsman\Ids\ValueObject\Exception;
+
+/** @psalm-immutable */
+final class IdListDoesContainEveryId extends \DomainException
+{
+    public function __construct()
+    {
+        parent::__construct('The id list does contain every id of list');
+    }
+}

--- a/src/ValueObject/Exception/IdListDoesContainNoneIds.php
+++ b/src/ValueObject/Exception/IdListDoesContainNoneIds.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DigitalCraftsman\Ids\ValueObject\Exception;
+
+/** @psalm-immutable */
+final class IdListDoesContainNoneIds extends \DomainException
+{
+    public function __construct()
+    {
+        parent::__construct('The id list does not contain none ids of list');
+    }
+}

--- a/src/ValueObject/IdList.php
+++ b/src/ValueObject/IdList.php
@@ -194,6 +194,19 @@ abstract class IdList implements \IteratorAggregate, \Countable
         return new static($ids);
     }
 
+    /** @param T $id */
+    public function removeIdWhenInList(Id $id): static
+    {
+        $ids = [];
+        foreach ($this->ids as $currentId) {
+            if ($currentId->isNotEqualTo($id)) {
+                $ids[] = $currentId;
+            }
+        }
+
+        return new static($ids);
+    }
+
     /** @param static $idList */
     public function diff(self $idList): static
     {

--- a/src/ValueObject/IdList.php
+++ b/src/ValueObject/IdList.php
@@ -176,10 +176,20 @@ abstract class IdList implements \IteratorAggregate, \Countable
     /** @param T $id */
     public function removeId(Id $id): static
     {
-        $ids = array_filter(
-            $this->ids,
-            static fn (Id $currentId) => $currentId->isNotEqualTo($id),
-        );
+        $wasIdFound = false;
+
+        $ids = [];
+        foreach ($this->ids as $currentId) {
+            if ($currentId->isNotEqualTo($id)) {
+                $ids[] = $currentId;
+            } else {
+                $wasIdFound = true;
+            }
+        }
+
+        if (!$wasIdFound) {
+            throw new IdListDoesNotContainId($id);
+        }
 
         return new static($ids);
     }

--- a/src/ValueObject/IdList.php
+++ b/src/ValueObject/IdList.php
@@ -118,23 +118,18 @@ abstract class IdList implements \IteratorAggregate, \Countable
         return new static($ids);
     }
 
-    /**
-     * @template TT of T
-     *
-     * @param array<int, Id> $ids
-     *
-     * @psalm-param array<int, TT> $ids
-     */
-    public function addIds(array $ids): static
+    /** @param static $idList */
+    public function addIds(self $idList): static
     {
-        foreach ($ids as $id) {
+        // TODO: Use must contain none ids
+        foreach ($idList as $id) {
             if ($this->containsId($id)) {
                 throw new IdAlreadyInList($id);
             }
         }
 
         $newIds = $this->ids;
-        foreach ($ids as $id) {
+        foreach ($idList as $id) {
             $newIds[] = $id;
         }
 
@@ -154,17 +149,11 @@ abstract class IdList implements \IteratorAggregate, \Countable
         return new static($ids);
     }
 
-    /**
-     * @template TT of T
-     *
-     * @param array<int, Id> $ids
-     *
-     * @psalm-param array<int, TT> $ids
-     */
-    public function addIdsWhenNotInList(array $ids): static
+    /** @param static $idList */
+    public function addIdsWhenNotInList(self $idList): static
     {
         $newIds = $this->ids;
-        foreach ($ids as $id) {
+        foreach ($idList as $id) {
             if ($this->notContainsId($id)) {
                 $newIds[] = $id;
             }
@@ -194,31 +183,21 @@ abstract class IdList implements \IteratorAggregate, \Countable
         return new static($ids);
     }
 
-    /**
-     * @template TT of T
-     *
-     * @param array<int, Id> $ids
-     *
-     * @psalm-param array<int, TT> $ids
-     */
-    public function removeIds(array $ids): static
+    /** @param static $idList */
+    public function removeIds(self $idList): static
     {
-        foreach ($ids as $id) {
-            // The strict value is used explicitly to convey the importance of not validating strictly. It has to use a string cast.
-            if (!in_array($id, $this->ids, false)) {
-                throw new IdListDoesNotContainId($id);
+        foreach ($idList as $id) {
+            $this->mustContainId($id);
+        }
+
+        $ids = [];
+        foreach ($this->ids as $id) {
+            if ($idList->notContainsId($id)) {
+                $ids[] = $id;
             }
         }
 
-        $remainingIds = [];
-        foreach ($this->ids as $currentId) {
-            // The strict value is used explicitly to convey the importance of not validating strictly. It has to use a string cast.
-            if (!in_array($currentId, $ids, false)) {
-                $remainingIds[] = $currentId;
-            }
-        }
-
-        return new static($remainingIds);
+        return new static($ids);
     }
 
     /** @param T $id */
@@ -234,24 +213,17 @@ abstract class IdList implements \IteratorAggregate, \Countable
         return new static($ids);
     }
 
-    /**
-     * @template TT of T
-     *
-     * @param array<int, Id> $ids
-     *
-     * @psalm-param array<int, TT> $ids
-     */
-    public function removeIdsWhenInList(array $ids): static
+    /** @param static $idList */
+    public function removeIdsWhenInList(self $idList): static
     {
-        $remainingIds = [];
-        foreach ($this->ids as $currentId) {
-            // The strict value is used explicitly to convey the importance of not validating strictly. It has to use a string cast.
-            if (!in_array($currentId, $ids, false)) {
-                $remainingIds[] = $currentId;
+        $ids = [];
+        foreach ($this->ids as $id) {
+            if ($idList->notContainsId($id)) {
+                $ids[] = $id;
             }
         }
 
-        return new static($remainingIds);
+        return new static($ids);
     }
 
     /** @param static $idList */

--- a/src/ValueObject/IdList.php
+++ b/src/ValueObject/IdList.php
@@ -7,9 +7,11 @@ namespace DigitalCraftsman\Ids\ValueObject;
 use DigitalCraftsman\Ids\ValueObject\Exception\DuplicateIds;
 use DigitalCraftsman\Ids\ValueObject\Exception\IdAlreadyInList;
 use DigitalCraftsman\Ids\ValueObject\Exception\IdClassNotHandledInList;
+use DigitalCraftsman\Ids\ValueObject\Exception\IdListDoesContainEveryId;
 use DigitalCraftsman\Ids\ValueObject\Exception\IdListDoesContainId;
 use DigitalCraftsman\Ids\ValueObject\Exception\IdListDoesNotContainEveryId;
 use DigitalCraftsman\Ids\ValueObject\Exception\IdListDoesNotContainId;
+use DigitalCraftsman\Ids\ValueObject\Exception\IdListDoesContainNoneIds;
 use DigitalCraftsman\Ids\ValueObject\Exception\IdListDoesNotContainSomeIds;
 use DigitalCraftsman\Ids\ValueObject\Exception\IdListIsNotEmpty;
 use DigitalCraftsman\Ids\ValueObject\Exception\IdListsMustBeEqual;
@@ -121,12 +123,7 @@ abstract class IdList implements \IteratorAggregate, \Countable
     /** @param static $idList */
     public function addIds(self $idList): static
     {
-        // TODO: Use must contain none ids
-        foreach ($idList as $id) {
-            if ($this->containsId($id)) {
-                throw new IdAlreadyInList($id);
-            }
-        }
+        $this->mustContainNoneIds($idList);
 
         $newIds = $this->ids;
         foreach ($idList as $id) {
@@ -186,9 +183,7 @@ abstract class IdList implements \IteratorAggregate, \Countable
     /** @param static $idList */
     public function removeIds(self $idList): static
     {
-        foreach ($idList as $id) {
-            $this->mustContainId($id);
-        }
+        $this->mustContainEveryId($idList);
 
         $ids = [];
         foreach ($this->ids as $id) {
@@ -343,6 +338,18 @@ abstract class IdList implements \IteratorAggregate, \Countable
         return true;
     }
 
+    public function notContainsEveryId(self $idList): bool
+    {
+        foreach ($idList as $id) {
+            if ($this->notContainsId($id)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /** Opposite function is not called notContainsSomeIds, but containsNoneIds */
     public function containsSomeIds(self $idList): bool
     {
         foreach ($idList as $id) {
@@ -352,6 +359,17 @@ abstract class IdList implements \IteratorAggregate, \Countable
         }
 
         return false;
+    }
+
+    public function containsNoneIds(self $idList): bool
+    {
+        foreach ($idList as $id) {
+            if ($this->containsId($id)) {
+                return false;
+            }
+        }
+
+        return true;
     }
 
     /** @param static $idList */
@@ -453,11 +471,27 @@ abstract class IdList implements \IteratorAggregate, \Countable
         }
     }
 
+    /** @throws IdListDoesContainEveryId */
+    public function mustNotContainEveryId(self $idList): void
+    {
+        if (!$this->notContainsEveryId($idList)) {
+            throw new IdListDoesContainEveryId();
+        }
+    }
+
     /** @throws IdListDoesNotContainSomeIds */
     public function mustContainSomeIds(self $idList): void
     {
         if (!$this->containsSomeIds($idList)) {
             throw new IdListDoesNotContainSomeIds();
+        }
+    }
+
+    /** @throws IdListDoesContainNoneIds */
+    public function mustContainNoneIds(self $idList): void
+    {
+        if (!$this->containsNoneIds($idList)) {
+            throw new IdListDoesContainNoneIds();
         }
     }
 

--- a/src/ValueObject/IdList.php
+++ b/src/ValueObject/IdList.php
@@ -194,6 +194,33 @@ abstract class IdList implements \IteratorAggregate, \Countable
         return new static($ids);
     }
 
+    /**
+     * @template TT of T
+     *
+     * @param array<int, Id> $ids
+     *
+     * @psalm-param array<int, TT> $ids
+     */
+    public function removeIds(array $ids): static
+    {
+        foreach ($ids as $id) {
+            // The strict value is used explicitly to convey the importance of not validating strictly. It has to use a string cast.
+            if (!in_array($id, $this->ids, false)) {
+                throw new IdListDoesNotContainId($id);
+            }
+        }
+
+        $remainingIds = [];
+        foreach ($this->ids as $currentId) {
+            // The strict value is used explicitly to convey the importance of not validating strictly. It has to use a string cast.
+            if (!in_array($currentId, $ids, false)) {
+                $remainingIds[] = $currentId;
+            }
+        }
+
+        return new static($remainingIds);
+    }
+
     /** @param T $id */
     public function removeIdWhenInList(Id $id): static
     {
@@ -205,6 +232,26 @@ abstract class IdList implements \IteratorAggregate, \Countable
         }
 
         return new static($ids);
+    }
+
+    /**
+     * @template TT of T
+     *
+     * @param array<int, Id> $ids
+     *
+     * @psalm-param array<int, TT> $ids
+     */
+    public function removeIdsWhenInList(array $ids): static
+    {
+        $remainingIds = [];
+        foreach ($this->ids as $currentId) {
+            // The strict value is used explicitly to convey the importance of not validating strictly. It has to use a string cast.
+            if (!in_array($currentId, $ids, false)) {
+                $remainingIds[] = $currentId;
+            }
+        }
+
+        return new static($remainingIds);
     }
 
     /** @param static $idList */

--- a/src/ValueObject/IdList.php
+++ b/src/ValueObject/IdList.php
@@ -118,6 +118,29 @@ abstract class IdList implements \IteratorAggregate, \Countable
         return new static($ids);
     }
 
+    /**
+     * @template TT of T
+     *
+     * @param array<int, Id> $ids
+     *
+     * @psalm-param array<int, TT> $ids
+     */
+    public function addIds(array $ids): static
+    {
+        foreach ($ids as $id) {
+            if ($this->containsId($id)) {
+                throw new IdAlreadyInList($id);
+            }
+        }
+
+        $newIds = $this->ids;
+        foreach ($ids as $id) {
+            $newIds[] = $id;
+        }
+
+        return new static($newIds);
+    }
+
     /** @param T $id */
     public function addIdWhenNotInList(Id $id): static
     {
@@ -129,6 +152,25 @@ abstract class IdList implements \IteratorAggregate, \Countable
         $ids[] = $id;
 
         return new static($ids);
+    }
+
+    /**
+     * @template TT of T
+     *
+     * @param array<int, Id> $ids
+     *
+     * @psalm-param array<int, TT> $ids
+     */
+    public function addIdsWhenNotInList(array $ids): static
+    {
+        $newIds = $this->ids;
+        foreach ($ids as $id) {
+            if ($this->notContainsId($id)) {
+                $newIds[] = $id;
+            }
+        }
+
+        return new static($newIds);
     }
 
     /** @param T $id */

--- a/tests/ValueObject/IdListTest.php
+++ b/tests/ValueObject/IdListTest.php
@@ -443,6 +443,28 @@ final class IdListTest extends TestCase
         self::assertTrue($removedList->notContainsId($idToRemove));
     }
 
+    /**
+     * @test
+     *
+     * @covers ::removeId
+     */
+    public function remove_id_fails_when_id_is_not_in_list(): void
+    {
+        // -- Assert
+        $this->expectException(IdListDoesNotContainId::class);
+
+        // -- Arrange
+        $idToRemove = UserId::generateRandom();
+
+        $idList = new UserIdList([
+            UserId::generateRandom(),
+            UserId::generateRandom(),
+        ]);
+
+        // -- Act
+        $idList->removeId($idToRemove);
+    }
+
     // -- Diff
 
     /**

--- a/tests/ValueObject/IdListTest.php
+++ b/tests/ValueObject/IdListTest.php
@@ -468,6 +468,105 @@ final class IdListTest extends TestCase
     /**
      * @test
      *
+     * @covers ::removeIds
+     */
+    public function remove_ids_works(): void
+    {
+        // -- Arrange
+        $idToRemove1 = UserId::generateRandom();
+        $idToRemove2 = UserId::generateRandom();
+
+        $idList = new UserIdList([
+            $idToRemove1,
+            $idToRemove2,
+            UserId::generateRandom(),
+            UserId::generateRandom(),
+        ]);
+
+        $idsToRemove = [
+            $idToRemove1,
+            $idToRemove2,
+        ];
+
+        // -- Act
+        $removedList = $idList->removeIds($idsToRemove);
+
+        // -- Assert
+        self::assertCount(4, $idList);
+        self::assertCount(2, $removedList);
+
+        self::assertTrue($removedList->notContainsId($idToRemove1));
+        self::assertTrue($removedList->notContainsId($idToRemove2));
+    }
+
+    /**
+     * @test
+     *
+     * @covers ::removeIds
+     */
+    public function remove_ids_fails_when_id_is_not_in_list(): void
+    {
+        // -- Assert
+        $this->expectException(IdListDoesNotContainId::class);
+
+        // -- Arrange
+        $idToRemove1 = UserId::generateRandom();
+        $idToRemove2 = UserId::generateRandom();
+
+        $idList = new UserIdList([
+            $idToRemove1,
+            UserId::generateRandom(),
+            UserId::generateRandom(),
+        ]);
+
+        $idsToRemove = [
+            $idToRemove1,
+            $idToRemove2,
+        ];
+
+        // -- Act
+        $idList->removeIds($idsToRemove);
+    }
+
+    /**
+     * @test
+     *
+     * @covers ::removeIdsWhenInList
+     */
+    public function remove_ids_when_in_list_works(): void
+    {
+        // -- Arrange
+        $idToRemove1 = UserId::generateRandom();
+        $idToRemove2 = UserId::generateRandom();
+        $idToRemove3 = UserId::generateRandom();
+
+        $idList = new UserIdList([
+            $idToRemove1,
+            $idToRemove2,
+            UserId::generateRandom(),
+            UserId::generateRandom(),
+        ]);
+
+        $idsToRemove = [
+            $idToRemove1,
+            $idToRemove2,
+            $idToRemove3,
+        ];
+
+        // -- Act
+        $removedList = $idList->removeIdsWhenInList($idsToRemove);
+
+        // -- Assert
+        self::assertCount(4, $idList);
+        self::assertCount(2, $removedList);
+
+        self::assertTrue($removedList->notContainsId($idToRemove1));
+        self::assertTrue($removedList->notContainsId($idToRemove2));
+    }
+
+    /**
+     * @test
+     *
      * @covers ::removeIdWhenInList
      */
     public function remove_id_when_in_list_works(): void

--- a/tests/ValueObject/IdListTest.php
+++ b/tests/ValueObject/IdListTest.php
@@ -341,10 +341,10 @@ final class IdListTest extends TestCase
             UserId::generateRandom(),
         ]);
 
-        $newIds = [
+        $newIds = new UserIdList([
             UserId::generateRandom(),
             UserId::generateRandom(),
-        ];
+        ]);
 
         // -- Act
         $addedList = $idList->addIds($newIds);
@@ -353,7 +353,7 @@ final class IdListTest extends TestCase
         self::assertCount(2, $idList);
         self::assertCount(4, $addedList);
 
-        self::assertTrue($addedList->containsEveryId(new UserIdList($newIds)));
+        self::assertTrue($addedList->containsEveryId($newIds));
     }
 
     /**
@@ -374,10 +374,10 @@ final class IdListTest extends TestCase
             UserId::generateRandom(),
         ]);
 
-        $newIds = [
+        $newIds = new UserIdList([
             $existingUserId,
             UserId::generateRandom(),
-        ];
+        ]);
 
         // -- Act
         $idList->addIds($newIds);
@@ -399,10 +399,10 @@ final class IdListTest extends TestCase
 
         $newId = UserId::generateRandom();
 
-        $newIds = [
+        $newIds = new UserIdList([
             $existingId,
             $newId,
-        ];
+        ]);
 
         // -- Act
         $addedList = $idList->addIdsWhenNotInList($newIds);
@@ -483,10 +483,10 @@ final class IdListTest extends TestCase
             UserId::generateRandom(),
         ]);
 
-        $idsToRemove = [
+        $idsToRemove = new UserIdList([
             $idToRemove1,
             $idToRemove2,
-        ];
+        ]);
 
         // -- Act
         $removedList = $idList->removeIds($idsToRemove);
@@ -519,10 +519,10 @@ final class IdListTest extends TestCase
             UserId::generateRandom(),
         ]);
 
-        $idsToRemove = [
+        $idsToRemove = new UserIdList([
             $idToRemove1,
             $idToRemove2,
-        ];
+        ]);
 
         // -- Act
         $idList->removeIds($idsToRemove);
@@ -547,11 +547,11 @@ final class IdListTest extends TestCase
             UserId::generateRandom(),
         ]);
 
-        $idsToRemove = [
+        $idsToRemove = new UserIdList([
             $idToRemove1,
             $idToRemove2,
             $idToRemove3,
-        ];
+        ]);
 
         // -- Act
         $removedList = $idList->removeIdsWhenInList($idsToRemove);

--- a/tests/ValueObject/IdListTest.php
+++ b/tests/ValueObject/IdListTest.php
@@ -465,6 +465,35 @@ final class IdListTest extends TestCase
         $idList->removeId($idToRemove);
     }
 
+    /**
+     * @test
+     *
+     * @covers ::removeIdWhenInList
+     */
+    public function remove_id_when_in_list_works(): void
+    {
+        // -- Arrange
+        $idToRemove = UserId::generateRandom();
+
+        $idList = new UserIdList([
+            $idToRemove,
+            UserId::generateRandom(),
+            UserId::generateRandom(),
+        ]);
+
+        $idNotInList = UserId::generateRandom();
+
+        // -- Act
+        $removedList = $idList->removeIdWhenInList($idToRemove);
+        $removedList = $removedList->removeIdWhenInList($idNotInList);
+
+        // -- Assert
+        self::assertCount(3, $idList);
+        self::assertCount(2, $removedList);
+
+        self::assertTrue($removedList->notContainsId($idToRemove));
+    }
+
     // -- Diff
 
     /**

--- a/tests/ValueObject/IdListTest.php
+++ b/tests/ValueObject/IdListTest.php
@@ -326,6 +326,95 @@ final class IdListTest extends TestCase
         self::assertTrue($addedList->containsId($newId));
     }
 
+    // -- Add ids
+
+    /**
+     * @test
+     *
+     * @covers ::addIds
+     */
+    public function add_ids_works(): void
+    {
+        // -- Arrange
+        $idList = new UserIdList([
+            UserId::generateRandom(),
+            UserId::generateRandom(),
+        ]);
+
+        $newIds = [
+            UserId::generateRandom(),
+            UserId::generateRandom(),
+        ];
+
+        // -- Act
+        $addedList = $idList->addIds($newIds);
+
+        // -- Assert
+        self::assertCount(2, $idList);
+        self::assertCount(4, $addedList);
+
+        self::assertTrue($addedList->containsEveryId(new UserIdList($newIds)));
+    }
+
+    /**
+     * @test
+     *
+     * @covers ::addIds
+     */
+    public function add_ids_fails_with_duplicate_id(): void
+    {
+        // -- Assert
+        $this->expectException(IdAlreadyInList::class);
+
+        // -- Arrange
+        $existingUserId = UserId::generateRandom();
+
+        $idList = new UserIdList([
+            $existingUserId,
+            UserId::generateRandom(),
+        ]);
+
+        $newIds = [
+            $existingUserId,
+            UserId::generateRandom(),
+        ];
+
+        // -- Act
+        $idList->addIds($newIds);
+    }
+
+    /**
+     * @test
+     *
+     * @covers ::addIdsWhenNotInList
+     */
+    public function add_ids_when_not_in_list_works(): void
+    {
+        // -- Arrange
+        $existingId = UserId::generateRandom();
+        $idList = new UserIdList([
+            $existingId,
+            UserId::generateRandom(),
+        ]);
+
+        $newId = UserId::generateRandom();
+
+        $newIds = [
+            $existingId,
+            $newId,
+        ];
+
+        // -- Act
+        $addedList = $idList->addIdsWhenNotInList($newIds);
+
+        // -- Assert
+        self::assertCount(2, $idList);
+        self::assertCount(3, $addedList);
+
+        self::assertTrue($addedList->containsId($existingId));
+        self::assertTrue($addedList->containsId($newId));
+    }
+
     // -- Remove id
 
     /**

--- a/tests/ValueObject/IdListTest.php
+++ b/tests/ValueObject/IdListTest.php
@@ -477,8 +477,8 @@ final class IdListTest extends TestCase
         $idToRemove2 = UserId::generateRandom();
 
         $idList = new UserIdList([
-            $idToRemove1,
-            $idToRemove2,
+            UserId::fromString((string) $idToRemove1),
+            UserId::fromString((string) $idToRemove2),
             UserId::generateRandom(),
             UserId::generateRandom(),
         ]);
@@ -541,8 +541,8 @@ final class IdListTest extends TestCase
         $idToRemove3 = UserId::generateRandom();
 
         $idList = new UserIdList([
-            $idToRemove1,
-            $idToRemove2,
+            UserId::fromString((string) $idToRemove1),
+            UserId::fromString((string) $idToRemove2),
             UserId::generateRandom(),
             UserId::generateRandom(),
         ]);


### PR DESCRIPTION
## Changes

- Updated method `removeId` from `IdList` to throw an exception when the id is not in the list. This is the same behaviour as the `addId` method has.
- Added new method `removeIdWhenInList(Id $id): static` to `IdList`.
- Added new method `addIds(self $idList): static` to `IdList`.
- Added new method `addIdsWhenNotInList(self $idList): static` to `IdList`.
- Added new method `removeIds(self $idList): static` to `IdList`.
- Added new method `removeIdsWhenInList(self $idList): static` to `IdList`.
- Added new method `notContainsEveryId(self $idList): bool` to `IdList`.
- Added new method `containsNoneIds(self $idList): bool` to `IdList`.
- Added new method `mustNotContainEveryId(self $idList): void` to `IdList`.
- Added new method `mustContainNoneIds(self $idList): void` to `IdList`.

Resolves #39 
Resolves #34 