### PR TITLE
Changed abstract method types to enable automatic registration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.11.0
+
+- **[Breaking change](./UPGRADE.md#changed-abstract-methods-of-types)**: Changed abstract methods of types to be `public` and `static` to enable automatic registration.
+
 ## 0.10.0
 
 - **[Breaking change](./UPGRADE.md#dropped-support-for-symfony-below-63)**: Dropped support for Symfony below 6.3.

--- a/README.md
+++ b/README.md
@@ -135,6 +135,8 @@ doctrine:
       user_id: App\Doctrine\UserIdType
 ```
 
+Alternatively you can also add a compiler pass to [register the types automatically](https://blog.digital-craftsman.de/automatically-register-doctrine-types-in-symfony-with-compiler-pass/).
+
 Then you're already able to add it into your entity like this:
 
 ```php

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -1,5 +1,90 @@
 # Upgrade guide
 
+## From 0.10.* to 0.11.0
+
+### Changed abstract methods of types
+
+They are now `public` and `static` to enable automatic registration.
+And the function `getIdListClass` from `IdListType` was renamed to `getClass`.
+
+Before:
+
+```php
+final class UserIdType extends IdType
+{
+    protected function getTypeName(): string
+    {
+        return 'user_id';
+    }
+
+    protected function getClass(): string
+    {
+        return UserId::class;
+    }
+}
+```
+
+After:
+
+```php
+final class UserIdType extends IdType
+{
+    public static function getTypeName(): string
+    {
+        return 'user_id';
+    }
+
+    public static function getClass(): string
+    {
+        return UserId::class;
+    }
+}
+```
+
+Before:
+
+```php
+final class UserIdListType extends IdListType
+{
+    protected function getTypeName(): string
+    {
+        return 'user_id_list';
+    }
+
+    protected function getIdListClass(): string
+    {
+        return UserIdList::class;
+    }
+
+    protected function getIdClass(): string
+    {
+        return UserId::class;
+    }
+}
+```
+
+After:
+
+```php
+final class UserIdListType extends IdListType
+{
+    public static function getTypeName(): string
+    {
+        return 'user_id_list';
+    }
+
+    public static function getClass(): string
+    {
+        return UserIdList::class;
+    }
+
+    public static function getIdClass(): string
+    {
+        return UserId::class;
+    }
+}
+```
+
 ## From 0.9.* to 0.10.0
 
 ### Dropped support for Symfony below 6.3

--- a/src/Doctrine/IdListType.php
+++ b/src/Doctrine/IdListType.php
@@ -12,13 +12,13 @@ use Doctrine\DBAL\Types\Type;
 
 abstract class IdListType extends Type
 {
-    abstract protected function getTypeName(): string;
+    abstract public static function getTypeName(): string;
 
     /** @psalm-return class-string<IdList|OrderedIdList> */
-    abstract protected function getIdListClass(): string;
+    abstract public static function getClass(): string;
 
     /** @psalm-return class-string<Id> */
-    abstract protected function getIdClass(): string;
+    abstract public static function getIdClass(): string;
 
     /** @codeCoverageIgnore */
     public function getSQLDeclaration(array $column, AbstractPlatform $platform): string
@@ -43,26 +43,24 @@ abstract class IdListType extends Type
             return null;
         }
 
-        $idListClass = $this->getIdListClass();
-        $idClass = $this->getIdClass();
+        $idListClass = static::getClass();
+        $idClass = static::getIdClass();
 
         /** @var array<int, string> $idStrings */
         $idStrings = json_decode($value, true, 512, JSON_THROW_ON_ERROR);
 
         $ids = [];
         foreach ($idStrings as $idString) {
-            /** @noinspection PhpUndefinedMethodInspection */
             $ids[] = new $idClass($idString);
         }
 
-        /** @noinspection PhpUndefinedMethodInspection */
         return new $idListClass($ids);
     }
 
     /** @codeCoverageIgnore */
     public function getName(): string
     {
-        return $this->getTypeName();
+        return static::getTypeName();
     }
 
     /** @codeCoverageIgnore */

--- a/src/Doctrine/IdType.php
+++ b/src/Doctrine/IdType.php
@@ -10,10 +10,10 @@ use Doctrine\DBAL\Types\Type;
 
 abstract class IdType extends Type
 {
-    abstract protected function getTypeName(): string;
+    abstract public static function getTypeName(): string;
 
     /** @return class-string<Id> */
-    abstract protected function getIdClass(): string;
+    abstract public static function getClass(): string;
 
     /** @codeCoverageIgnore */
     public function getSQLDeclaration(array $column, AbstractPlatform $platform): string
@@ -38,13 +38,13 @@ abstract class IdType extends Type
             return null;
         }
 
-        return $this->getIdClass()::fromString($value);
+        return static::getClass()::fromString($value);
     }
 
     /** @codeCoverageIgnore */
     public function getName(): string
     {
-        return $this->getTypeName();
+        return static::getTypeName();
     }
 
     /** @codeCoverageIgnore */

--- a/tests/Test/Doctrine/OrderedUserIdListType.php
+++ b/tests/Test/Doctrine/OrderedUserIdListType.php
@@ -10,17 +10,17 @@ use DigitalCraftsman\Ids\Test\ValueObject\UserId;
 
 final class OrderedUserIdListType extends IdListType
 {
-    protected function getTypeName(): string
+    public static function getTypeName(): string
     {
         return 'ordered_user_id_list';
     }
 
-    protected function getIdListClass(): string
+    public static function getClass(): string
     {
         return OrderedUserIdList::class;
     }
 
-    protected function getIdClass(): string
+    public static function getIdClass(): string
     {
         return UserId::class;
     }

--- a/tests/Test/Doctrine/UserIdListType.php
+++ b/tests/Test/Doctrine/UserIdListType.php
@@ -10,17 +10,17 @@ use DigitalCraftsman\Ids\Test\ValueObject\UserIdList;
 
 final class UserIdListType extends IdListType
 {
-    protected function getTypeName(): string
+    public static function getTypeName(): string
     {
         return 'user_id_list';
     }
 
-    protected function getIdListClass(): string
+    public static function getClass(): string
     {
         return UserIdList::class;
     }
 
-    protected function getIdClass(): string
+    public static function getIdClass(): string
     {
         return UserId::class;
     }

--- a/tests/Test/Doctrine/UserIdType.php
+++ b/tests/Test/Doctrine/UserIdType.php
@@ -9,12 +9,12 @@ use DigitalCraftsman\Ids\Test\ValueObject\UserId;
 
 final class UserIdType extends IdType
 {
-    protected function getTypeName(): string
+    public static function getTypeName(): string
     {
         return 'user_id';
     }
 
-    protected function getIdClass(): string
+    public static function getClass(): string
     {
         return UserId::class;
     }


### PR DESCRIPTION
## Changes

- Changed abstract methods of types to be `public` and `static` to enable automatic registration.

Resolves #43 