### PR TITLE
Use JSONB for IdList doctrine type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.14.0
+
+- **[Breaking change](./UPGRADE.md#converted-database-column-type-from-json-to-jsonb-for-idlisttype)**: Converted database column type from `JSON` to `JSONB` for `IdListType` to improve comparison performance and enable index creation.
+
 ## 0.13.0
 
 - Added compatibility for Symfony 7.

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ composer require digital-craftsman/ids
 
 It's recommended that you install the [`uuid` PHP extension](https://pecl.php.net/package/uuid) for better performance of id creation and validation.  `symfony/polyfill-uuid` is used as a fallback. You can [prevent installing the polyfill](./docs/prevent-polyfill-usage.md) when you've installed the PHP extension.
 
-> ⚠️ This bundle can be used (and is being used) in production, but hasn't reached version 1.0 yet. Therefore, there will be breaking changes between minor versions. I'd recommend that you require the bundle only with the current minor version like `composer require digital-craftsman/ids:0.13.*`. Breaking changes are described in the releases and [the changelog](./CHANGELOG.md). Updates are described in the [upgrade guide](./UPGRADE.md).
+> ⚠️ This bundle can be used (and is being used) in production, but hasn't reached version 1.0 yet. Therefore, there will be breaking changes between minor versions. I'd recommend that you require the bundle only with the current minor version like `composer require digital-craftsman/ids:0.14.*`. Breaking changes are described in the releases and [the changelog](./CHANGELOG.md). Updates are described in the [upgrade guide](./UPGRADE.md).
 
 ## Working with ids
 

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -1,5 +1,17 @@
 # Upgrade guide
 
+## From 0.13.* to 0.14.0
+
+### Converted database column type from `JSON` to `JSONB` for `IdListType`
+
+The database column type for `IdListType` was converted from `JSON` to `JSONB` to improve comparison performance and enable index creation. The migration for existing lists need to be created manually as Doctrine doesn't realize the changes (as `JSONB` is just an option for `JSON` in doctrine).
+
+Search your project for usages of the id lists and create a migration to set the column type to `JSONB` for the id lists. A migration query could look like this:
+
+```sql
+ALTER TABLE project ALTER COLUMN ids_of_users_with_access SET DATA TYPE JSONB USING ids_of_users_with_access::jsonb;
+```
+
 ## From 0.12.* to 0.13.0
 
 Nothing to do.

--- a/src/Doctrine/IdListType.php
+++ b/src/Doctrine/IdListType.php
@@ -22,7 +22,7 @@ abstract class IdListType extends Type
     /** @codeCoverageIgnore */
     public function getSQLDeclaration(array $column, AbstractPlatform $platform): string
     {
-        $column['options']['jsonb'] = true;
+        $column['jsonb'] = true;
 
         return $platform->getJsonTypeDeclarationSQL($column);
     }

--- a/src/Doctrine/IdListType.php
+++ b/src/Doctrine/IdListType.php
@@ -22,6 +22,8 @@ abstract class IdListType extends Type
     /** @codeCoverageIgnore */
     public function getSQLDeclaration(array $column, AbstractPlatform $platform): string
     {
+        $column['options']['jsonb'] = true;
+
         return $platform->getJsonTypeDeclarationSQL($column);
     }
 


### PR DESCRIPTION
## Changes

- Searching through `JSONB` is faster then `JSON`. Therefore, the IdLists are now creating `JSONB` columns. As it's still the same type, the migration needs to be created manually (doctrine doesn't realize the difference).