### PR TITLE
Add option to throw custom exceptions in guards

### DIFF
--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -41,5 +41,8 @@ return (new PhpCsFixer\Config())
 
         // Nullable types should be explicit even with default values
         'nullable_type_declaration_for_default_null_value' => false,
+
+        // Throw in a single line is worse to read when using ternary operator
+        'single_line_throw' => false,
     ])
     ->setFinder($finder);

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## 1.1.0
+
+- Added option to supply a custom exception to the guard methods of `Id` and `IdList`. This allows for more specific exceptions when the guard fails.
+
+Example of using the new (optional) parameter:
+```php
+$requestingUser->userId->mustNotBeEqualTo(
+    $command->targetUserId,
+    static fn () => new Exception\UserCanNotTargetItself(),
+);
+```
+
 ## 1.0.0
 
 Reached stability after 2 years of usage in multiple scaled production systems.

--- a/README.md
+++ b/README.md
@@ -52,8 +52,17 @@ if ($userId->isEqualTo($command->userId)) {
 }
 ```
 
+Guard against invalid usages:
 ```php
 $requestingUser->userId->mustNotBeEqualTo($command->targetUserId);
+```
+
+Or with a custom exception:
+```php
+$requestingUser->userId->mustNotBeEqualTo(
+    $command->targetUserId,
+    static fn () => new Exception\UserCanNotTargetItself(),
+);
 ```
 
 ### Symfony serializer

--- a/README.md
+++ b/README.md
@@ -211,8 +211,17 @@ if ($idsOfEnabledUsers->contains($command->userId)) {
 }
 ```
 
+Guard against invalid usages:
 ```php
-$idsOfEnabledUsers->mustContain($command->targetUserId);
+$idsOfEnabledUsers->mustContainId($command->targetUserId);
+```
+
+Or with custom exception:
+```php
+$idsOfEnabledUsers->mustContainId(
+    $command->targetUserId,
+    static fn () => new Exception\UserIsNotEnabled(),
+);
 ```
 
 ### Symfony serializer

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -1,5 +1,9 @@
 # Upgrade guide
 
+## From 1.0.0 to 1.1.0
+
+Nothing to do.
+
 ## From 0.15.* to 1.0.0
 
 Nothing to do.

--- a/src/ValueObject/Id.php
+++ b/src/ValueObject/Id.php
@@ -47,19 +47,37 @@ abstract readonly class Id implements \Stringable
 
     // Guards
 
-    /** @throws Exception\IdNotEqual */
-    public function mustBeEqualTo(self $id): void
-    {
+    /**
+     * @param ?callable(): \Throwable $exception
+     *
+     * @throws \Throwable
+     * @throws Exception\IdNotEqual
+     */
+    public function mustBeEqualTo(
+        self $id,
+        ?callable $exception = null,
+    ): void {
         if ($this->isNotEqualTo($id)) {
-            throw new Exception\IdNotEqual($this, $id);
+            throw $exception !== null
+                ? $exception()
+                : new Exception\IdNotEqual($this, $id);
         }
     }
 
-    /** @throws Exception\IdEqual */
-    public function mustNotBeEqualTo(self $id): void
-    {
+    /**
+     * @param ?callable(): \Throwable $exception
+     *
+     * @throws \Throwable
+     * @throws Exception\IdEqual
+     */
+    public function mustNotBeEqualTo(
+        self $id,
+        ?callable $exception = null,
+    ): void {
         if ($this->isEqualTo($id)) {
-            throw new Exception\IdEqual($this, $id);
+            throw $exception !== null
+                ? $exception()
+                : new Exception\IdEqual($this, $id);
         }
     }
 }

--- a/src/ValueObject/IdList.php
+++ b/src/ValueObject/IdList.php
@@ -23,7 +23,9 @@ abstract readonly class IdList implements \IteratorAggregate, \Countable
 
     // -- Construction
 
-    /** @param array<array-key, T> $ids */
+    /**
+     * @param array<array-key, T> $ids
+     */
     final public function __construct(
         array $ids,
     ) {
@@ -412,90 +414,174 @@ abstract readonly class IdList implements \IteratorAggregate, \Countable
     // -- Guards
 
     /**
-     * @param T $id
+     * @param T                       $id
+     * @param ?callable(): \Throwable $exception
      *
+     * @throws \Throwable
      * @throws Exception\IdListDoesNotContainId
      */
-    public function mustContainId(Id $id): void
-    {
+    public function mustContainId(
+        Id $id,
+        ?callable $exception = null,
+    ): void {
         if ($this->notContainsId($id)) {
-            throw new Exception\IdListDoesNotContainId($id);
+            throw $exception !== null
+                ? $exception()
+                : new Exception\IdListDoesNotContainId($id);
         }
     }
 
     /**
-     * @param T $id
+     * @param T                       $id
+     * @param ?callable(): \Throwable $exception
      *
+     * @throws \Throwable
      * @throws Exception\IdListDoesContainId
      */
-    public function mustNotContainId(Id $id): void
-    {
+    public function mustNotContainId(
+        Id $id,
+        ?callable $exception = null,
+    ): void {
         if ($this->containsId($id)) {
-            throw new Exception\IdListDoesContainId($id);
+            throw $exception !== null
+                ? $exception()
+                : new Exception\IdListDoesContainId($id);
         }
     }
 
-    /** @throws Exception\IdListDoesNotContainEveryId */
-    public function mustContainEveryId(self $idList): void
-    {
+    /**
+     * @param ?callable(): \Throwable $exception
+     *
+     * @throws \Throwable
+     * @throws Exception\IdListDoesNotContainEveryId
+     */
+    public function mustContainEveryId(
+        self $idList,
+        ?callable $exception = null,
+    ): void {
         if (!$this->containsEveryId($idList)) {
-            throw new Exception\IdListDoesNotContainEveryId();
+            throw $exception !== null
+                ? $exception()
+                : new Exception\IdListDoesNotContainEveryId();
         }
     }
 
-    /** @throws Exception\IdListDoesContainEveryId */
-    public function mustNotContainEveryId(self $idList): void
-    {
+    /**
+     * @param ?callable(): \Throwable $exception
+     *
+     * @throws \Throwable
+     * @throws Exception\IdListDoesContainEveryId
+     */
+    public function mustNotContainEveryId(
+        self $idList,
+        ?callable $exception = null,
+    ): void {
         if (!$this->notContainsEveryId($idList)) {
-            throw new Exception\IdListDoesContainEveryId();
+            throw $exception !== null
+                ? $exception()
+                : new Exception\IdListDoesContainEveryId();
         }
     }
 
-    /** @throws Exception\IdListDoesNotContainSomeIds */
-    public function mustContainSomeIds(self $idList): void
-    {
+    /**
+     * @param ?callable(): \Throwable $exception
+     *
+     * @throws \Throwable
+     * @throws Exception\IdListDoesNotContainSomeIds
+     */
+    public function mustContainSomeIds(
+        self $idList,
+        ?callable $exception = null,
+    ): void {
         if (!$this->containsSomeIds($idList)) {
-            throw new Exception\IdListDoesNotContainSomeIds();
+            throw $exception !== null
+                ? $exception()
+                : new Exception\IdListDoesNotContainSomeIds();
         }
     }
 
-    /** @throws Exception\IdListDoesContainNoneIds */
-    public function mustContainNoneIds(self $idList): void
-    {
+    /**
+     * @param ?callable(): \Throwable $exception
+     *
+     * @throws \Throwable
+     * @throws Exception\IdListDoesContainNoneIds
+     */
+    public function mustContainNoneIds(
+        self $idList,
+        ?callable $exception = null,
+    ): void {
         if (!$this->containsNoneIds($idList)) {
-            throw new Exception\IdListDoesContainNoneIds();
+            throw $exception !== null
+                ? $exception()
+                : new Exception\IdListDoesContainNoneIds();
         }
     }
 
-    /** @throws Exception\IdListIsNotEmpty */
-    public function mustBeEmpty(): void
-    {
+    /**
+     * @param ?callable(): \Throwable $exception
+     *
+     * @throws \Throwable
+     * @throws Exception\IdListIsNotEmpty
+     */
+    public function mustBeEmpty(
+        ?callable $exception = null,
+    ): void {
         if ($this->isNotEmpty()) {
-            throw new Exception\IdListIsNotEmpty();
+            throw $exception !== null
+                ? $exception()
+                : new Exception\IdListIsNotEmpty();
         }
     }
 
-    /** @throws Exception\IdListIsEmpty */
-    public function mustNotBeEmpty(): void
-    {
+    /**
+     * @param ?callable(): \Throwable $exception
+     *
+     * @throws \Throwable
+     * @throws Exception\IdListIsEmpty
+     */
+    public function mustNotBeEmpty(
+        ?callable $exception = null,
+    ): void {
         if ($this->isEmpty()) {
-            throw new Exception\IdListIsEmpty();
+            throw $exception !== null
+                ? $exception()
+                : new Exception\IdListIsEmpty();
         }
     }
 
-    /** @param static $idList */
-    public function mustBeEqualTo(self $idList): void
-    {
+    /**
+     * @param static                  $idList
+     * @param ?callable(): \Throwable $exception
+     *
+     * @throws \Throwable
+     * @throws Exception\IdListsMustBeEqual
+     */
+    public function mustBeEqualTo(
+        self $idList,
+        ?callable $exception = null,
+    ): void {
         if ($this->isNotEqualTo($idList)) {
-            throw new Exception\IdListsMustBeEqual();
+            throw $exception !== null
+                ? $exception()
+                : new Exception\IdListsMustBeEqual();
         }
     }
 
-    /** @param static $idList */
-    public function mustNotBeEqualTo(self $idList): void
-    {
+    /**
+     * @param static                  $idList
+     * @param ?callable(): \Throwable $exception
+     *
+     * @throws \Throwable
+     * @throws Exception\IdListsMustNotBeEqual
+     */
+    public function mustNotBeEqualTo(
+        self $idList,
+        ?callable $exception = null,
+    ): void {
         if ($this->isEqualTo($idList)) {
-            throw new Exception\IdListsMustNotBeEqual();
+            throw $exception !== null
+                ? $exception()
+                : new Exception\IdListsMustNotBeEqual();
         }
     }
 

--- a/tests/Test/Exception/AllUsersMustBeAbleToPerformAction.php
+++ b/tests/Test/Exception/AllUsersMustBeAbleToPerformAction.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DigitalCraftsman\Ids\Test\Exception;
+
+final class AllUsersMustBeAbleToPerformAction extends \InvalidArgumentException
+{
+}

--- a/tests/Test/Exception/ListOfUsersHasNotChanged.php
+++ b/tests/Test/Exception/ListOfUsersHasNotChanged.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DigitalCraftsman\Ids\Test\Exception;
+
+final class ListOfUsersHasNotChanged extends \InvalidArgumentException
+{
+}

--- a/tests/Test/Exception/NoUserCanPerformAction.php
+++ b/tests/Test/Exception/NoUserCanPerformAction.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DigitalCraftsman\Ids\Test\Exception;
+
+final class NoUserCanPerformAction extends \InvalidArgumentException
+{
+}

--- a/tests/Test/Exception/NotAllUsersAreDisabled.php
+++ b/tests/Test/Exception/NotAllUsersAreDisabled.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DigitalCraftsman\Ids\Test\Exception;
+
+final class NotAllUsersAreDisabled extends \InvalidArgumentException
+{
+}

--- a/tests/Test/Exception/NotAllUsersAreEnabled.php
+++ b/tests/Test/Exception/NotAllUsersAreEnabled.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DigitalCraftsman\Ids\Test\Exception;
+
+final class NotAllUsersAreEnabled extends \InvalidArgumentException
+{
+}

--- a/tests/Test/Exception/NotTheSameUser.php
+++ b/tests/Test/Exception/NotTheSameUser.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DigitalCraftsman\Ids\Test\Exception;
+
+final class NotTheSameUser extends \InvalidArgumentException
+{
+}

--- a/tests/Test/Exception/SameUser.php
+++ b/tests/Test/Exception/SameUser.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DigitalCraftsman\Ids\Test\Exception;
+
+final class SameUser extends \InvalidArgumentException
+{
+}

--- a/tests/Test/Exception/SomeUsersAreAlreadyEnabled.php
+++ b/tests/Test/Exception/SomeUsersAreAlreadyEnabled.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DigitalCraftsman\Ids\Test\Exception;
+
+final class SomeUsersAreAlreadyEnabled extends \InvalidArgumentException
+{
+}

--- a/tests/Test/Exception/ThereAreStillUsersWithIssues.php
+++ b/tests/Test/Exception/ThereAreStillUsersWithIssues.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DigitalCraftsman\Ids\Test\Exception;
+
+final class ThereAreStillUsersWithIssues extends \InvalidArgumentException
+{
+}

--- a/tests/Test/Exception/ThereMustBeAtLeastOneUserWithAccess.php
+++ b/tests/Test/Exception/ThereMustBeAtLeastOneUserWithAccess.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DigitalCraftsman\Ids\Test\Exception;
+
+final class ThereMustBeAtLeastOneUserWithAccess extends \InvalidArgumentException
+{
+}

--- a/tests/Test/Exception/UserIsDisabled.php
+++ b/tests/Test/Exception/UserIsDisabled.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DigitalCraftsman\Ids\Test\Exception;
+
+final class UserIsDisabled extends \InvalidArgumentException
+{
+}

--- a/tests/Test/Exception/UserIsNotEnabled.php
+++ b/tests/Test/Exception/UserIsNotEnabled.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DigitalCraftsman\Ids\Test\Exception;
+
+final class UserIsNotEnabled extends \InvalidArgumentException
+{
+}

--- a/tests/ValueObject/IdTest.php
+++ b/tests/ValueObject/IdTest.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace DigitalCraftsman\Ids\ValueObject;
 
+use DigitalCraftsman\Ids\Test\Exception\NotTheSameUser;
+use DigitalCraftsman\Ids\Test\Exception\SameUser;
 use DigitalCraftsman\Ids\Test\ValueObject\UserId;
 use PHPUnit\Framework\TestCase;
 
@@ -125,6 +127,27 @@ final class IdTest extends TestCase
     /**
      * @test
      *
+     * @covers ::mustBeEqualTo
+     */
+    public function user_id_must_be_equal_fails_with_custom_exception(): void
+    {
+        // -- Assert
+        $this->expectException(NotTheSameUser::class);
+
+        // -- Arrange
+        $userId1 = UserId::generateRandom();
+        $userId2 = UserId::generateRandom();
+
+        // -- Act
+        $userId1->mustBeEqualTo(
+            $userId2,
+            static fn () => new NotTheSameUser(),
+        );
+    }
+
+    /**
+     * @test
+     *
      * @covers ::mustNotBeEqualTo
      */
     public function user_id_must_not_be_equal_fails(): void
@@ -138,5 +161,26 @@ final class IdTest extends TestCase
 
         // -- Act
         $userId1->mustNotBeEqualTo($userId2);
+    }
+
+    /**
+     * @test
+     *
+     * @covers ::mustNotBeEqualTo
+     */
+    public function user_id_must_not_be_equal_fails_with_custom_exception(): void
+    {
+        // -- Assert
+        $this->expectException(SameUser::class);
+
+        // -- Arrange
+        $userId1 = UserId::generateRandom();
+        $userId2 = new UserId((string) $userId1);
+
+        // -- Act
+        $userId1->mustNotBeEqualTo(
+            $userId2,
+            static fn () => new SameUser(),
+        );
     }
 }


### PR DESCRIPTION
## Changes

- Guard methods include an option to throw custom exceptions.
- Tests and docs have been updated.
- Prepared release 1.1.0.